### PR TITLE
22 versionize docker images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   release:
-    types: [created]
+    types: [ created ]
 
 env:
   REGISTRY: ghcr.io
@@ -47,25 +47,46 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build all JARs
-        run: |
-          for service in PaymentService ProductsService OrderService UserService; do
-            mvn clean package -DskipTests -f $service/pom.xml
-          done
+      - name: Build Payment Service Jar
+        run: mvn clean package -DskipTests -f PaymentService/pom.xml
 
-      - name: Build and push Docker images
-        run: |
-          services=("payments" "products" "orders" "users")
-          directories=("PaymentService" "ProductsService" "OrderService" "UserService")
-          
-          for i in "${!services[@]}"; do
-            service=${services[$i]}
-            directory=${directories[$i]}
-          
-            # Build and push using docker/build-push-action
-            uses: docker/build-push-action@v6
-            with:
-              context: ./$directory
-              push: true
-              tags: ${{ steps.meta.outputs.tags }}-${{ service }}
-              labels: ${{ steps.meta.outputs.labels }}
+      - name: Build Products Service Jar
+        run: mvn clean package -DskipTests -f ProductsService/pom.xml
+
+      - name: Build Order Service Jar
+        run: mvn clean package -DskipTests -f OrderService/pom.xml
+
+      - name: Build User Service Jar
+        run: mvn clean package -DskipTests -f UserService/pom.xml
+
+      - name: Build and push Payment Docker images
+        uses: docker/build-push-action@v6
+        with:
+          context: ./PaymentService
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Build and push Products Docker images
+        uses: docker/build-push-action@v6
+        with:
+          context: ./ProductsService
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Build and push Order Docker images
+        uses: docker/build-push-action@v6
+        with:
+          context: ./OrderService
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Build and push User Docker images
+        uses: docker/build-push-action@v6
+        with:
+          context: ./UserService
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,66 +4,68 @@ on:
   push:
     branches:
       - main
+  release:
+    types: [created]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
     steps:
-      - name: Checkout the code
+      - name: Checkout repository
         uses: actions/checkout@v4
 
-      # Set up Java for Maven
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
 
-      # Log in to GitHub Container Registry
-      - name: Log in to GitHub Container Registry
+      - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_PAT2 }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Build the Spring Boot applications using Maven
-      - name: Build payment-service JAR
-        run: mvn clean package -DskipTests
-        working-directory: PaymentService
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=sha
 
-      - name: Build product-service JAR
-        run: mvn clean package -DskipTests
-        working-directory: ProductsService
-
-      - name: Build order-service JAR
-        run: mvn clean package -DskipTests
-        working-directory: OrderService
-
-      - name: Build user-service JAR
-        run: mvn clean package -DskipTests
-        working-directory: UserService
-
-      # Set up Docker Buildx
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push payment-service image
+      - name: Build all JARs
         run: |
-          docker build -t ghcr.io/${{ github.actor }}/commercify_payments:latest ./PaymentService
-          docker push ghcr.io/${{ github.actor }}/commercify_payments:latest
+          for service in PaymentService ProductsService OrderService UserService; do
+            mvn clean package -DskipTests -f $service/pom.xml
+          done
 
-      - name: Build and push product-service image
+      - name: Build and push Docker images
         run: |
-          docker build -t ghcr.io/${{ github.actor }}/commercify_products:latest ./ProductsService
-          docker push ghcr.io/${{ github.actor }}/commercify_products:latest
-
-      - name: Build and push order-service image
-        run: |
-          docker build -t ghcr.io/${{ github.actor }}/commercify_orders:latest ./OrderService
-          docker push ghcr.io/${{ github.actor }}/commercify_orders:latest
-
-      - name: Build and push user-service image
-        run: |
-          docker build -t ghcr.io/${{ github.actor }}/commercify_users:latest ./UserService
-          docker push ghcr.io/${{ github.actor }}/commercify_users:latest
+          services=("payments" "products" "orders" "users")
+          directories=("PaymentService" "ProductsService" "OrderService" "UserService")
+          
+          for i in "${!services[@]}"; do
+            service=${services[$i]}
+            directory=${directories[$i]}
+          
+            # Build and push using docker/build-push-action
+            uses: docker/build-push-action@v6
+            with:
+              context: ./$directory
+              push: true
+              tags: ${{ steps.meta.outputs.tags }}-${{ service }}
+              labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This pull request includes significant updates to the GitHub Actions workflow for Docker publishing in the `.github/workflows/docker-publish.yml` file. The changes aim to streamline the build and push process for Docker images and improve the overall workflow configuration.

Workflow enhancements:

* Added a new `release` trigger to the workflow to handle release events. (`.github/workflows/docker-publish.yml` [.github/workflows/docker-publish.ymlR7-R92](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R7-R92))
* Introduced environment variables `REGISTRY` and `IMAGE_NAME` to centralize and simplify registry and image name configuration. (`.github/workflows/docker-publish.yml` [.github/workflows/docker-publish.ymlR7-R92](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R7-R92))
* Updated job permissions to include `contents: read` and `packages: write` for better security and functionality. (`.github/workflows/docker-publish.yml` [.github/workflows/docker-publish.ymlR7-R92](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R7-R92))

Docker build and push improvements:

* Replaced individual Maven build steps for each service with a more concise format using `-f` to specify the `pom.xml` file location. (`.github/workflows/docker-publish.yml` [.github/workflows/docker-publish.ymlR7-R92](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R7-R92))
* Switched from manual Docker build and push commands to using `docker/build-push-action@v6` for each service, incorporating metadata for tags and labels. (`.github/workflows/docker-publish.yml` [.github/workflows/docker-publish.ymlR7-R92](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R7-R92))