### PR TITLE
docker images version part 2

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -47,18 +47,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      #      - name: Build Payment Service Jar
-      #        run: mvn clean package -DskipTests -f PaymentService/pom.xml
-      #
-      #      - name: Build Products Service Jar
-      #        run: mvn clean package -DskipTests -f ProductsService/pom.xml
-      #
-      #      - name: Build Order Service Jar
-      #        run: mvn clean package -DskipTests -f OrderService/pom.xml
-      #
-      #      - name: Build User Service Jar
-      #        run: mvn clean package -DskipTests -f UserService/pom.xml
-
       - name: Build all JARs
         run: |
           for service in PaymentService ProductsService OrderService UserService; do


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/docker-publish.yml` file, which consolidates the build steps for multiple services into a single step.

Workflow optimization:

* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L50-L61): Removed individual build steps for `PaymentService`, `ProductsService`, `OrderService`, and `UserService` and replaced them with a single loop to build all JARs in one step.