### PR TITLE
include method

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,9 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        services:
-          - service: [ PaymentService, ProductsService, OrderService, UserService ]
-            docker_services: [ payment, products, order, user ]
+        include:
+          - service: PaymentService
+            docker_service: payment
+          - service: ProductsService
+            docker_service: products
+          - service: OrderService
+            docker_service: order
+          - service: UserService
+            docker_service: user
 
     permissions:
       contents: read
@@ -44,7 +50,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}/commercify_${{ matrix.services.docker_services }}
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/commercify_${{ matrix.include.docker_service }}
           tags: |
             type=ref,event=branch
             type=sha
@@ -53,12 +59,12 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build JAR
-        run: mvn clean package -DskipTests -f ${{ matrix.services.service }}/pom.xml
+        run: mvn clean package -DskipTests -f ${{ matrix.include.service }}/pom.xml
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
-          context: ./${{ matrix.services.service }}
+          context: ./${{ matrix.include.service }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/docker-publish.yml` file to improve the configuration of the Docker publishing workflow. The most important changes involve modifying the matrix strategy to use `include` instead of `services`, and updating the related references to align with this new structure.

Changes to matrix strategy:

* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L18-R26): Changed matrix strategy from using `services` to using `include` for better clarity and maintainability.

Updates to Docker image metadata and build process:

* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L47-R53): Updated Docker image metadata action to reference `matrix.include.docker_service` instead of `matrix.services.docker_services`.
* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L56-R67): Modified Maven build command to use `matrix.include.service` instead of `matrix.services.service`.
* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L56-R67): Updated Docker build context to use `matrix.include.service` instead of `matrix.services.service`.