### PR TITLE
Docker publish rework

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -50,7 +50,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}/commercify_${{ matrix.docker_service }}
+          images: ${{ env.REGISTRY }}/commercify_${{ matrix.docker_service }}
           tags: |
             type=ref,event=branch
             type=sha

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,13 +17,13 @@ jobs:
       matrix:
         include:
           - service: PaymentService
-            docker_service: payment
+            docker_service: payments
           - service: ProductsService
             docker_service: products
           - service: OrderService
-            docker_service: order
+            docker_service: orders
           - service: UserService
-            docker_service: user
+            docker_service: users
 
     permissions:
       contents: read


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/docker-publish.yml` file to update the naming conventions for Docker services and streamline the Docker metadata action configuration.

Updates to Docker service names:

* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L20-R26): Updated `docker_service` names for `PaymentService`, `OrderService`, and `UserService` to use plural forms for consistency. (`payment` to `payments`, `order` to `orders`, `user` to `users`)

Streamlining Docker metadata action configuration:

* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L53-R53): Removed redundant `${{ github.repository }}` from the `images` field in the `docker/metadata-action` configuration.