### PR TITLE
quick docker image release

### DIFF
--- a/.github/workflows/docker-quick-release.yml
+++ b/.github/workflows/docker-quick-release.yml
@@ -1,0 +1,67 @@
+name: Build and Push Dev Docker Images to GHCR
+
+on:
+  push:
+    branches:
+      - development
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - service: PaymentService
+            docker_service: payments
+          - service: ProductsService
+            docker_service: products
+          - service: OrderService
+            docker_service: orders
+          - service: UserService
+            docker_service: users
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PAT2 }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.actor }}/commercify_${{ matrix.docker_service }}
+          tags: |
+            type=raw,value=dev
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build JAR
+        run: mvn clean package -DskipTests -f ${{ matrix.service }}/pom.xml
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./${{ matrix.service }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/ProductsService/src/main/java/com/gostavdev/commercify/productsservice/configs/SecurityConfig.java
+++ b/ProductsService/src/main/java/com/gostavdev/commercify/productsservice/configs/SecurityConfig.java
@@ -25,7 +25,10 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity
                 .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(req -> req.anyRequest().authenticated())
+                .authorizeHttpRequests(req -> req
+                        .requestMatchers("api/v1/products/active").permitAll()
+                        .anyRequest().authenticated()
+                )
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .cors(c -> c.configurationSource(corsConfigurationSource()))
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building and pushing Docker images for development branches and updates the security configuration in the `ProductsService` to allow unauthenticated access to a specific endpoint.

### New GitHub Actions Workflow:

* [`.github/workflows/docker-quick-release.yml`](diffhunk://#diff-9e4261cb877deda4bd9fdb1cf0ece4b67a3531926e5e566a8a393ca0a2e35840R1-R67): Added a workflow to build and push Docker images to GitHub Container Registry (GHCR) for the development branch.
### Security Configuration Update:

* [`ProductsService/src/main/java/com/gostavdev/commercify/productsservice/configs/SecurityConfig.java`](diffhunk://#diff-d250556214e80a82c877b75e460cc5ef28671ddaf5e9a9762001003142defa6aL28-R31): Modified the security configuration to allow unauthenticated access to the `api/v1/products/active` endpoint while keeping other endpoints authenticated.