### PR TITLE
Better testing environment changes

### DIFF
--- a/cmd/seed/main.go
+++ b/cmd/seed/main.go
@@ -544,7 +544,7 @@ func seedProductVariants(db *sql.DB) error {
 			price        float64
 			comparePrice float64
 			stock        int
-			attributes   map[string]string
+			attributes   []map[string]string
 			isDefault    bool
 			productID    int
 			images       string
@@ -565,7 +565,7 @@ func seedProductVariants(db *sql.DB) error {
 						price        float64
 						comparePrice float64
 						stock        int
-						attributes   map[string]string
+						attributes   []map[string]string
 						isDefault    bool
 						productID    int
 						images       string
@@ -574,10 +574,13 @@ func seedProductVariants(db *sql.DB) error {
 						price:        basePrice,
 						comparePrice: comparePrice,
 						stock:        50 - (i * 10) - (j * 5),
-						attributes:   map[string]string{"color": color, "capacity": capacity, "title": fmt.Sprintf("%s - %s, %s", product.name, color, capacity)},
-						isDefault:    isDefault,
-						productID:    product.id,
-						images:       fmt.Sprintf(`["%s_%s.jpg"]`, strings.ToLower(strings.ReplaceAll(product.name, " ", "")), strings.ToLower(color)),
+						attributes: []map[string]string{
+							{"name": "Color", "value": color},
+							{"name": "Capacity", "value": capacity},
+						},
+						isDefault: isDefault,
+						productID: product.id,
+						images:    fmt.Sprintf(`["%s_%s.jpg"]`, strings.ToLower(strings.ReplaceAll(product.name, " ", "")), strings.ToLower(color)),
 					})
 				}
 			}
@@ -599,7 +602,7 @@ func seedProductVariants(db *sql.DB) error {
 						price        float64
 						comparePrice float64
 						stock        int
-						attributes   map[string]string
+						attributes   []map[string]string
 						isDefault    bool
 						productID    int
 						images       string
@@ -608,12 +611,10 @@ func seedProductVariants(db *sql.DB) error {
 						price:        basePrice,
 						comparePrice: comparePrice,
 						stock:        20 - (i * 2) - (j * 1),
-						attributes: map[string]string{
-							"color":       color,
-							"size":        size,
-							"material":    materialOptions[i%len(materialOptions)],
-							"title":       fmt.Sprintf("%s - %s, Size %s", product.name, color, size),
-							"description": fmt.Sprintf("%s in %s, Size %s", product.name, color, size),
+						attributes: []map[string]string{
+							{"name": "Color", "value": color},
+							{"name": "Size", "value": size},
+							{"name": "Material", "value": materialOptions[i%len(materialOptions)]},
 						},
 						isDefault: isDefault,
 						productID: product.id,
@@ -638,7 +639,7 @@ func seedProductVariants(db *sql.DB) error {
 						price        float64
 						comparePrice float64
 						stock        int
-						attributes   map[string]string
+						attributes   []map[string]string
 						isDefault    bool
 						productID    int
 						images       string
@@ -647,11 +648,9 @@ func seedProductVariants(db *sql.DB) error {
 						price:        basePrice,
 						comparePrice: comparePrice,
 						stock:        15 - (i * 3) - (j * 2),
-						attributes: map[string]string{
-							"ram":         ram,
-							"storage":     storage,
-							"title":       fmt.Sprintf("%s - %s RAM, %s Storage", product.name, ram, storage),
-							"description": fmt.Sprintf("%s with %s RAM and %s storage", product.name, ram, storage),
+						attributes: []map[string]string{
+							{"name": "RAM", "value": ram},
+							{"name": "Storage", "value": storage},
 						},
 						isDefault: isDefault,
 						productID: product.id,

--- a/cmd/seed/main.go
+++ b/cmd/seed/main.go
@@ -126,19 +126,19 @@ func main() {
 		fmt.Println("Carts seeded successfully")
 	}
 
-	if *allFlag || *ordersFlag {
-		if err := seedOrders(db); err != nil {
-			log.Fatalf("Failed to seed orders: %v", err)
-		}
-		fmt.Println("Orders seeded successfully")
-	}
+	// if *allFlag || *ordersFlag {
+	// 	if err := seedOrders(db); err != nil {
+	// 		log.Fatalf("Failed to seed orders: %v", err)
+	// 	}
+	// 	fmt.Println("Orders seeded successfully")
+	// }
 
-	if *allFlag || *paymentTransactionsFlag {
-		if err := seedPaymentTransactions(db); err != nil {
-			log.Fatalf("Failed to seed payment transactions: %v", err)
-		}
-		fmt.Println("Payment transactions seeded successfully")
-	}
+	// if *allFlag || *paymentTransactionsFlag {
+	// 	if err := seedPaymentTransactions(db); err != nil {
+	// 		log.Fatalf("Failed to seed payment transactions: %v", err)
+	// 	}
+	// 	fmt.Println("Payment transactions seeded successfully")
+	// }
 
 	if !*allFlag && !*usersFlag && !*categoriesFlag && !*productsFlag && !*productVariantsFlag &&
 		!*ordersFlag && !*clearFlag && !*discountsFlag && !*cartsFlag && !*webhooksFlag &&

--- a/internal/application/usecase/cart_usecase_test.go
+++ b/internal/application/usecase/cart_usecase_test.go
@@ -21,7 +21,7 @@ func TestCartUseCase_GetOrCreateCart(t *testing.T) {
 		userID := uint(1)
 		cart, _ := entity.NewCart(userID)
 		cart.ID = 1
-		cartRepo.CreateWithID(cart)
+		cartRepo.Create(cart)
 
 		// Create use case with mocks
 		cartUseCase := usecase.NewCartUseCase(cartRepo, productRepo)
@@ -68,7 +68,7 @@ func TestCartUseCase_GetOrCreateGuestCart(t *testing.T) {
 			SessionID: sessionID,
 			Items:     []entity.CartItem{},
 		}
-		cartRepo.CreateWithID(cart)
+		cartRepo.Create(cart)
 
 		// Create use case with mocks
 		cartUseCase := usecase.NewCartUseCase(cartRepo, productRepo)
@@ -121,7 +121,7 @@ func TestCartUseCase_AddToCart(t *testing.T) {
 		userID := uint(1)
 		cart, _ := entity.NewCart(userID)
 		cart.ID = 1
-		cartRepo.CreateWithID(cart)
+		cartRepo.Create(cart)
 
 		// Create use case with mocks
 		cartUseCase := usecase.NewCartUseCase(cartRepo, productRepo)
@@ -180,7 +180,7 @@ func TestCartUseCase_AddToCart(t *testing.T) {
 		userID := uint(1)
 		cart, _ := entity.NewCart(userID)
 		cart.ID = 1
-		cartRepo.CreateWithID(cart)
+		cartRepo.Create(cart)
 
 		// Create use case with mocks
 		cartUseCase := usecase.NewCartUseCase(cartRepo, productRepo)
@@ -228,7 +228,7 @@ func TestCartUseCase_AddToCartWithVariant(t *testing.T) {
 		userID := uint(1)
 		cart, _ := entity.NewCart(userID)
 		cart.ID = 1
-		cartRepo.CreateWithID(cart)
+		cartRepo.Create(cart)
 
 		// Create use case with mocks
 		cartUseCase := usecase.NewCartUseCase(cartRepo, productRepo)
@@ -267,7 +267,7 @@ func TestCartUseCase_AddToCartWithVariant(t *testing.T) {
 		userID := uint(1)
 		cart, _ := entity.NewCart(userID)
 		cart.ID = 1
-		cartRepo.CreateWithID(cart)
+		cartRepo.Create(cart)
 
 		// Create use case with mocks
 		cartUseCase := usecase.NewCartUseCase(cartRepo, productRepo)
@@ -314,7 +314,7 @@ func TestCartUseCase_AddToCartWithVariant(t *testing.T) {
 		userID := uint(1)
 		cart, _ := entity.NewCart(userID)
 		cart.ID = 1
-		cartRepo.CreateWithID(cart)
+		cartRepo.Create(cart)
 
 		// Create use case with mocks
 		cartUseCase := usecase.NewCartUseCase(cartRepo, productRepo)
@@ -377,7 +377,7 @@ func TestCartUseCase_AddMultipleVariantsToCart(t *testing.T) {
 		userID := uint(1)
 		cart, _ := entity.NewCart(userID)
 		cart.ID = 1
-		cartRepo.CreateWithID(cart)
+		cartRepo.Create(cart)
 
 		// Create use case with mocks
 		cartUseCase := usecase.NewCartUseCase(cartRepo, productRepo)
@@ -462,7 +462,7 @@ func TestCartUseCase_MixedCartWithVariantsAndRegularProducts(t *testing.T) {
 		userID := uint(1)
 		cart, _ := entity.NewCart(userID)
 		cart.ID = 1
-		cartRepo.CreateWithID(cart)
+		cartRepo.Create(cart)
 
 		// Create use case with mocks
 		cartUseCase := usecase.NewCartUseCase(cartRepo, productRepo)
@@ -521,7 +521,7 @@ func TestCartUseCase_RemoveFromCartWithVariant(t *testing.T) {
 		cart.AddItem(1, 1, 2) // Product 1, Variant 1
 		cart.AddItem(1, 2, 1) // Product 1, Variant 2
 		cart.AddItem(2, 0, 3) // Product 2, No variant
-		cartRepo.CreateWithID(cart)
+		cartRepo.Create(cart)
 
 		// Create use case with mocks
 		cartUseCase := usecase.NewCartUseCase(cartRepo, productRepo)
@@ -569,7 +569,7 @@ func TestCartUseCase_RemoveFromCartWithVariant(t *testing.T) {
 		cart, _ := entity.NewCart(userID)
 		cart.ID = 1
 		cart.AddItem(1, 1, 2) // Product 1, Variant 1
-		cartRepo.CreateWithID(cart)
+		cartRepo.Create(cart)
 
 		// Create use case with mocks
 		cartUseCase := usecase.NewCartUseCase(cartRepo, productRepo)
@@ -617,7 +617,7 @@ func TestCartUseCase_AddToGuestCartWithVariant(t *testing.T) {
 			SessionID: sessionID,
 			Items:     []entity.CartItem{},
 		}
-		cartRepo.CreateWithID(cart)
+		cartRepo.Create(cart)
 
 		// Create use case with mocks
 		cartUseCase := usecase.NewCartUseCase(cartRepo, productRepo)
@@ -668,7 +668,7 @@ func TestCartUseCase_AddToGuestCartWithVariant(t *testing.T) {
 			SessionID: sessionID,
 			Items:     []entity.CartItem{},
 		}
-		cartRepo.CreateWithID(cart)
+		cartRepo.Create(cart)
 
 		// Create use case with mocks
 		cartUseCase := usecase.NewCartUseCase(cartRepo, productRepo)
@@ -727,7 +727,7 @@ func TestCartUseCase_UpdateGuestCartItemWithVariant(t *testing.T) {
 				},
 			},
 		}
-		cartRepo.CreateWithID(cart)
+		cartRepo.Create(cart)
 
 		// Create use case with mocks
 		cartUseCase := usecase.NewCartUseCase(cartRepo, productRepo)
@@ -783,7 +783,7 @@ func TestCartUseCase_RemoveFromGuestCartWithVariant(t *testing.T) {
 				},
 			},
 		}
-		cartRepo.CreateWithID(cart)
+		cartRepo.Create(cart)
 
 		// Create use case with mocks
 		cartUseCase := usecase.NewCartUseCase(cartRepo, productRepo)
@@ -849,7 +849,7 @@ func TestCartUseCase_ConvertGuestCartToUserCartWithVariants(t *testing.T) {
 				},
 			},
 		}
-		cartRepo.CreateWithID(guestCart)
+		cartRepo.Create(guestCart)
 
 		// Create use case with mocks
 		cartUseCase := usecase.NewCartUseCase(cartRepo, productRepo)
@@ -896,7 +896,7 @@ func TestCartUseCase_MergingCartWithVariants(t *testing.T) {
 		userCart.ID = 1
 		userCart.AddItem(1, 2, 1) // Product 1, Variant 2
 		userCart.AddItem(3, 0, 2) // Product 3, No variant
-		cartRepo.CreateWithID(userCart)
+		cartRepo.Create(userCart)
 
 		// Create a guest cart with some items
 		sessionID := "test-session-123"
@@ -926,7 +926,7 @@ func TestCartUseCase_MergingCartWithVariants(t *testing.T) {
 				},
 			},
 		}
-		cartRepo.CreateWithID(guestCart)
+		cartRepo.Create(guestCart)
 
 		// Create use case with mocks
 		cartUseCase := usecase.NewCartUseCase(cartRepo, productRepo)

--- a/internal/application/usecase/discount_usecase_test.go
+++ b/internal/application/usecase/discount_usecase_test.go
@@ -17,7 +17,7 @@ func TestDiscountUseCase_CreateDiscount(t *testing.T) {
 		discountRepo := mock.NewMockDiscountRepository()
 		productRepo := mock.NewMockProductRepository()
 		categoryRepo := mock.NewMockCategoryRepository()
-		orderRepo := mock.NewMockOrderRepository()
+		orderRepo := mock.NewMockOrderRepository(false)
 
 		// Create use case with mocks
 		discountUseCase := usecase.NewDiscountUseCase(
@@ -66,7 +66,7 @@ func TestDiscountUseCase_CreateDiscount(t *testing.T) {
 		discountRepo := mock.NewMockDiscountRepository()
 		productRepo := mock.NewMockProductRepository()
 		categoryRepo := mock.NewMockCategoryRepository()
-		orderRepo := mock.NewMockOrderRepository()
+		orderRepo := mock.NewMockOrderRepository(false)
 
 		// Create product
 		product := &entity.Product{
@@ -116,7 +116,7 @@ func TestDiscountUseCase_CreateDiscount(t *testing.T) {
 		discountRepo := mock.NewMockDiscountRepository()
 		productRepo := mock.NewMockProductRepository()
 		categoryRepo := mock.NewMockCategoryRepository()
-		orderRepo := mock.NewMockOrderRepository()
+		orderRepo := mock.NewMockOrderRepository(false)
 
 		// Create a test category
 		category := &entity.Category{
@@ -168,7 +168,7 @@ func TestDiscountUseCase_CreateDiscount(t *testing.T) {
 		discountRepo := mock.NewMockDiscountRepository()
 		productRepo := mock.NewMockProductRepository()
 		categoryRepo := mock.NewMockCategoryRepository()
-		orderRepo := mock.NewMockOrderRepository()
+		orderRepo := mock.NewMockOrderRepository(false)
 
 		// Create existing discount
 		existingDiscount, _ := entity.NewDiscount(
@@ -222,7 +222,7 @@ func TestDiscountUseCase_CreateDiscount(t *testing.T) {
 		discountRepo := mock.NewMockDiscountRepository()
 		productRepo := mock.NewMockProductRepository()
 		categoryRepo := mock.NewMockCategoryRepository()
-		orderRepo := mock.NewMockOrderRepository()
+		orderRepo := mock.NewMockOrderRepository(false)
 
 		// Create use case with mocks
 		discountUseCase := usecase.NewDiscountUseCase(
@@ -262,7 +262,7 @@ func TestDiscountUseCase_CreateDiscount(t *testing.T) {
 		discountRepo := mock.NewMockDiscountRepository()
 		productRepo := mock.NewMockProductRepository()
 		categoryRepo := mock.NewMockCategoryRepository()
-		orderRepo := mock.NewMockOrderRepository()
+		orderRepo := mock.NewMockOrderRepository(false)
 
 		// Create use case with mocks
 		discountUseCase := usecase.NewDiscountUseCase(
@@ -301,7 +301,7 @@ func TestDiscountUseCase_CreateDiscount(t *testing.T) {
 		discountRepo := mock.NewMockDiscountRepository()
 		productRepo := mock.NewMockProductRepository()
 		categoryRepo := mock.NewMockCategoryRepository()
-		orderRepo := mock.NewMockOrderRepository()
+		orderRepo := mock.NewMockOrderRepository(false)
 
 		// Create use case with mocks
 		discountUseCase := usecase.NewDiscountUseCase(
@@ -342,7 +342,7 @@ func TestDiscountUseCase_ProductSpecificDiscount(t *testing.T) {
 		discountRepo := mock.NewMockDiscountRepository()
 		productRepo := mock.NewMockProductRepository()
 		categoryRepo := mock.NewMockCategoryRepository()
-		orderRepo := mock.NewMockOrderRepository()
+		orderRepo := mock.NewMockOrderRepository(false)
 
 		// Create test products
 		product1 := &entity.Product{
@@ -401,7 +401,7 @@ func TestDiscountUseCase_ProductSpecificDiscount(t *testing.T) {
 		discountRepo := mock.NewMockDiscountRepository()
 		productRepo := mock.NewMockProductRepository()
 		categoryRepo := mock.NewMockCategoryRepository()
-		orderRepo := mock.NewMockOrderRepository()
+		orderRepo := mock.NewMockOrderRepository(false)
 
 		// Create test products
 		product1 := &entity.Product{
@@ -492,7 +492,7 @@ func TestDiscountUseCase_ProductSpecificDiscount(t *testing.T) {
 		discountRepo := mock.NewMockDiscountRepository()
 		productRepo := mock.NewMockProductRepository()
 		categoryRepo := mock.NewMockCategoryRepository()
-		orderRepo := mock.NewMockOrderRepository()
+		orderRepo := mock.NewMockOrderRepository(false)
 
 		// Create test products
 		product1 := &entity.Product{
@@ -583,7 +583,7 @@ func TestDiscountUseCase_ProductSpecificDiscount(t *testing.T) {
 		discountRepo := mock.NewMockDiscountRepository()
 		productRepo := mock.NewMockProductRepository()
 		categoryRepo := mock.NewMockCategoryRepository()
-		orderRepo := mock.NewMockOrderRepository()
+		orderRepo := mock.NewMockOrderRepository(false)
 
 		// Create test products
 		product1 := &entity.Product{
@@ -676,7 +676,7 @@ func TestDiscountUseCase_GetDiscountByID(t *testing.T) {
 		discountRepo := mock.NewMockDiscountRepository()
 		productRepo := mock.NewMockProductRepository()
 		categoryRepo := mock.NewMockCategoryRepository()
-		orderRepo := mock.NewMockOrderRepository()
+		orderRepo := mock.NewMockOrderRepository(false)
 
 		// Create a test discount
 		discount, _ := entity.NewDiscount(
@@ -716,7 +716,7 @@ func TestDiscountUseCase_GetDiscountByID(t *testing.T) {
 		discountRepo := mock.NewMockDiscountRepository()
 		productRepo := mock.NewMockProductRepository()
 		categoryRepo := mock.NewMockCategoryRepository()
-		orderRepo := mock.NewMockOrderRepository()
+		orderRepo := mock.NewMockOrderRepository(false)
 
 		// Create use case with mocks
 		discountUseCase := usecase.NewDiscountUseCase(
@@ -741,7 +741,7 @@ func TestDiscountUseCase_GetDiscountByCode(t *testing.T) {
 		discountRepo := mock.NewMockDiscountRepository()
 		productRepo := mock.NewMockProductRepository()
 		categoryRepo := mock.NewMockCategoryRepository()
-		orderRepo := mock.NewMockOrderRepository()
+		orderRepo := mock.NewMockOrderRepository(false)
 
 		// Create a test discount
 		discount, _ := entity.NewDiscount(
@@ -781,7 +781,7 @@ func TestDiscountUseCase_GetDiscountByCode(t *testing.T) {
 		discountRepo := mock.NewMockDiscountRepository()
 		productRepo := mock.NewMockProductRepository()
 		categoryRepo := mock.NewMockCategoryRepository()
-		orderRepo := mock.NewMockOrderRepository()
+		orderRepo := mock.NewMockOrderRepository(false)
 
 		// Create use case with mocks
 		discountUseCase := usecase.NewDiscountUseCase(
@@ -806,7 +806,7 @@ func TestDiscountUseCase_UpdateDiscount(t *testing.T) {
 		discountRepo := mock.NewMockDiscountRepository()
 		productRepo := mock.NewMockProductRepository()
 		categoryRepo := mock.NewMockCategoryRepository()
-		orderRepo := mock.NewMockOrderRepository()
+		orderRepo := mock.NewMockOrderRepository(false)
 
 		// Create a test discount
 		discount, _ := entity.NewDiscount(
@@ -860,7 +860,7 @@ func TestDiscountUseCase_UpdateDiscount(t *testing.T) {
 		discountRepo := mock.NewMockDiscountRepository()
 		productRepo := mock.NewMockProductRepository()
 		categoryRepo := mock.NewMockCategoryRepository()
-		orderRepo := mock.NewMockOrderRepository()
+		orderRepo := mock.NewMockOrderRepository(false)
 
 		// Create use case with mocks
 		discountUseCase := usecase.NewDiscountUseCase(
@@ -889,7 +889,7 @@ func TestDiscountUseCase_UpdateDiscount(t *testing.T) {
 		discountRepo := mock.NewMockDiscountRepository()
 		productRepo := mock.NewMockProductRepository()
 		categoryRepo := mock.NewMockCategoryRepository()
-		orderRepo := mock.NewMockOrderRepository()
+		orderRepo := mock.NewMockOrderRepository(false)
 
 		// Create two test discounts
 		discount1, _ := entity.NewDiscount(
@@ -950,7 +950,7 @@ func TestDiscountUseCase_DeleteDiscount(t *testing.T) {
 		discountRepo := mock.NewMockDiscountRepository()
 		productRepo := mock.NewMockProductRepository()
 		categoryRepo := mock.NewMockCategoryRepository()
-		orderRepo := mock.NewMockOrderRepository()
+		orderRepo := mock.NewMockOrderRepository(false)
 
 		// Create a test discount
 		discount, _ := entity.NewDiscount(
@@ -967,11 +967,6 @@ func TestDiscountUseCase_DeleteDiscount(t *testing.T) {
 			0,
 		)
 		discountRepo.Create(discount)
-
-		// Configure orderRepo mock to say discount is not used
-		orderRepo.MockIsDiscountIdUsed = func(id uint) (bool, error) {
-			return false, nil
-		}
 
 		// Create use case with mocks
 		discountUseCase := usecase.NewDiscountUseCase(
@@ -997,7 +992,7 @@ func TestDiscountUseCase_DeleteDiscount(t *testing.T) {
 		discountRepo := mock.NewMockDiscountRepository()
 		productRepo := mock.NewMockProductRepository()
 		categoryRepo := mock.NewMockCategoryRepository()
-		orderRepo := mock.NewMockOrderRepository()
+		orderRepo := mock.NewMockOrderRepository(true)
 
 		// Create a test discount
 		discount, _ := entity.NewDiscount(
@@ -1014,11 +1009,6 @@ func TestDiscountUseCase_DeleteDiscount(t *testing.T) {
 			0,
 		)
 		discountRepo.Create(discount)
-
-		// Configure orderRepo mock to say discount is used
-		orderRepo.MockIsDiscountIdUsed = func(id uint) (bool, error) {
-			return true, nil
-		}
 
 		// Create use case with mocks
 		discountUseCase := usecase.NewDiscountUseCase(
@@ -1047,7 +1037,7 @@ func TestDiscountUseCase_ListDiscounts(t *testing.T) {
 		discountRepo := mock.NewMockDiscountRepository()
 		productRepo := mock.NewMockProductRepository()
 		categoryRepo := mock.NewMockCategoryRepository()
-		orderRepo := mock.NewMockOrderRepository()
+		orderRepo := mock.NewMockOrderRepository(false)
 
 		// Create multiple test discounts
 		for i := 1; i <= 5; i++ {
@@ -1098,7 +1088,7 @@ func TestDiscountUseCase_ApplyDiscountToOrder(t *testing.T) {
 		discountRepo := mock.NewMockDiscountRepository()
 		productRepo := mock.NewMockProductRepository()
 		categoryRepo := mock.NewMockCategoryRepository()
-		orderRepo := mock.NewMockOrderRepository()
+		orderRepo := mock.NewMockOrderRepository(false)
 
 		// Create a test discount
 		discount, _ := entity.NewDiscount(
@@ -1173,7 +1163,7 @@ func TestDiscountUseCase_ApplyDiscountToOrder(t *testing.T) {
 		discountRepo := mock.NewMockDiscountRepository()
 		productRepo := mock.NewMockProductRepository()
 		categoryRepo := mock.NewMockCategoryRepository()
-		orderRepo := mock.NewMockOrderRepository()
+		orderRepo := mock.NewMockOrderRepository(false)
 
 		// Create a test category
 		category := &entity.Category{
@@ -1213,14 +1203,6 @@ func TestDiscountUseCase_ApplyDiscountToOrder(t *testing.T) {
 			0,
 		)
 		discountRepo.Create(discount)
-
-		// Set up product repo mock search behavior
-		productRepo.MockSearch = func(query string, categoryID uint, minPrice, maxPrice int64, offset, limit int) ([]*entity.Product, error) {
-			if categoryID == 1 {
-				return []*entity.Product{product1, product2}, nil
-			}
-			return []*entity.Product{}, nil
-		}
 
 		// Create test order items including products from the category
 		items := []entity.OrderItem{
@@ -1288,7 +1270,7 @@ func TestDiscountUseCase_ApplyDiscountToOrder(t *testing.T) {
 		discountRepo := mock.NewMockDiscountRepository()
 		productRepo := mock.NewMockProductRepository()
 		categoryRepo := mock.NewMockCategoryRepository()
-		orderRepo := mock.NewMockOrderRepository()
+		orderRepo := mock.NewMockOrderRepository(false)
 
 		// Create test order items
 		items := []entity.OrderItem{
@@ -1338,7 +1320,7 @@ func TestDiscountUseCase_RemoveDiscountFromOrder(t *testing.T) {
 		discountRepo := mock.NewMockDiscountRepository()
 		productRepo := mock.NewMockProductRepository()
 		categoryRepo := mock.NewMockCategoryRepository()
-		orderRepo := mock.NewMockOrderRepository()
+		orderRepo := mock.NewMockOrderRepository(false)
 
 		// Create a test discount
 		discount, _ := entity.NewDiscount(

--- a/internal/application/usecase/order_usecase.go
+++ b/internal/application/usecase/order_usecase.go
@@ -60,7 +60,7 @@ type CreateOrderInput struct {
 	Email            string         `json:"email,omitempty"`
 	PhoneNumber      string         `json:"phone_number,omitempty"`
 	FullName         string         `json:"full_name,omitempty"`
-	ShippingMethodID uint           `json:"shipping_method_id,omitempty"`
+	ShippingMethodID uint           `json:"shipping_method_id"`
 }
 
 // CreateOrderFromCart creates an order from a user's cart
@@ -79,6 +79,11 @@ func (uc *OrderUseCase) CreateOrderFromCart(input CreateOrderInput) (*entity.Ord
 
 // createOrderFromUserCart creates an order from an authenticated user's cart
 func (uc *OrderUseCase) createOrderFromUserCart(input CreateOrderInput) (*entity.Order, error) {
+	// Validate shipping method ID
+	if input.ShippingMethodID == 0 {
+		return nil, errors.New("shipping method ID is required")
+	}
+
 	// Get user's cart
 	cart, err := uc.cartRepo.GetByUserID(input.UserID)
 	if err != nil {
@@ -145,8 +150,11 @@ func (uc *OrderUseCase) createOrderFromUserCart(input CreateOrderInput) (*entity
 	// Set the total weight
 	order.TotalWeight = totalWeight
 
+	// Set shipping method ID
+	order.ShippingMethodID = input.ShippingMethodID
+
 	// Apply shipping method if specified
-	if input.ShippingMethodID > 0 && uc.shippingUseCase != nil {
+	if uc.shippingUseCase != nil {
 		shippingMethod, err := uc.shippingUseCase.GetShippingMethodByID(input.ShippingMethodID)
 		if err != nil {
 			return nil, errors.New("shipping method not found")
@@ -197,6 +205,11 @@ func (uc *OrderUseCase) createOrderFromGuestCart(input CreateOrderInput) (*entit
 
 	if input.FullName == "" {
 		return nil, errors.New("full name is required for guest checkout")
+	}
+
+	// Validate shipping method ID
+	if input.ShippingMethodID == 0 {
+		return nil, errors.New("shipping method ID is required")
 	}
 
 	// Get guest's cart
@@ -261,8 +274,11 @@ func (uc *OrderUseCase) createOrderFromGuestCart(input CreateOrderInput) (*entit
 	// Set the total weight
 	order.TotalWeight = totalWeight
 
+	// Set shipping method ID
+	order.ShippingMethodID = input.ShippingMethodID
+
 	// Apply shipping method if specified
-	if input.ShippingMethodID > 0 && uc.shippingUseCase != nil {
+	if uc.shippingUseCase != nil {
 		shippingMethod, err := uc.shippingUseCase.GetShippingMethodByID(input.ShippingMethodID)
 		if err != nil {
 			return nil, errors.New("shipping method not found")

--- a/internal/application/usecase/product_usecase_test.go
+++ b/internal/application/usecase/product_usecase_test.go
@@ -796,12 +796,6 @@ func TestProductUseCase_SearchProducts(t *testing.T) {
 	})
 }
 
-// Helper function for the search test
-func contains(s, substr string) bool {
-	return s != "" && substr != "" && (len(s) >= len(substr) && s[0:len(substr)] == substr ||
-		s != "" && substr != "" && (len(s) >= len(substr)) && s[len(s)-len(substr):] == substr)
-}
-
 func TestProductUseCase_DeleteProduct(t *testing.T) {
 	t.Run("Delete product successfully", func(t *testing.T) {
 		// Setup mocks

--- a/internal/application/usecase/product_usecase_test.go
+++ b/internal/application/usecase/product_usecase_test.go
@@ -1,6 +1,7 @@
 package usecase_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -741,45 +742,6 @@ func TestProductUseCase_SearchProducts(t *testing.T) {
 		}
 		productRepo.Create(product3)
 
-		// Configure mock search function
-		productRepo.MockSearch = func(query string, categoryID uint, minPrice, maxPrice int64, offset, limit int) ([]*entity.Product, error) {
-			results := make([]*entity.Product, 0)
-
-			// Simple implementation that checks if query is in name or description
-			for _, p := range []*entity.Product{product1, product2, product3} {
-				if query == "" ||
-					(len(query) > 0 && (contains(p.Name, query) || contains(p.Description, query))) {
-
-					// Apply category filter
-					if categoryID > 0 && p.CategoryID != categoryID {
-						continue
-					}
-
-					// Apply price filters
-					if minPrice > 0 && p.Price < minPrice {
-						continue
-					}
-					if maxPrice > 0 && p.Price > maxPrice {
-						continue
-					}
-
-					results = append(results, p)
-				}
-			}
-
-			// Apply offset and limit
-			if offset >= len(results) {
-				return []*entity.Product{}, nil
-			}
-
-			end := offset + limit
-			if end > len(results) {
-				end = len(results)
-			}
-
-			return results[offset:end], nil
-		}
-
 		// Create use case with mocks
 		productUseCase := usecase.NewProductUseCase(
 			productRepo,
@@ -795,6 +757,9 @@ func TestProductUseCase_SearchProducts(t *testing.T) {
 			Limit:  10,
 		}
 		results, err := productUseCase.SearchProducts(input)
+
+		// print results
+		fmt.Println(results)
 
 		// Assert
 		assert.NoError(t, err)

--- a/internal/application/usecase/product_usecase_test.go
+++ b/internal/application/usecase/product_usecase_test.go
@@ -756,7 +756,7 @@ func TestProductUseCase_SearchProducts(t *testing.T) {
 			Offset: 0,
 			Limit:  10,
 		}
-		results, err := productUseCase.SearchProducts(input)
+		results, _, err := productUseCase.SearchProducts(input)
 
 		// print results
 		fmt.Println(results)
@@ -773,7 +773,7 @@ func TestProductUseCase_SearchProducts(t *testing.T) {
 			Offset:     0,
 			Limit:      10,
 		}
-		results, err = productUseCase.SearchProducts(input)
+		results, _, err = productUseCase.SearchProducts(input)
 
 		// Assert
 		assert.NoError(t, err)
@@ -787,7 +787,7 @@ func TestProductUseCase_SearchProducts(t *testing.T) {
 			Offset:   0,
 			Limit:    10,
 		}
-		results, err = productUseCase.SearchProducts(input)
+		results, _, err = productUseCase.SearchProducts(input)
 
 		// Assert
 		assert.NoError(t, err)

--- a/internal/domain/common/session.go
+++ b/internal/domain/common/session.go
@@ -1,0 +1,6 @@
+package common
+
+const (
+	SessionCookieName = "guest_session_id"
+	SessionCookieAge  = 86400 * 30 // 30 days in seconds
+)

--- a/internal/domain/repository/cart_repository.go
+++ b/internal/domain/repository/cart_repository.go
@@ -8,6 +8,6 @@ type CartRepository interface {
 	GetByUserID(userID uint) (*entity.Cart, error)
 	GetBySessionID(sessionID string) (*entity.Cart, error)
 	Update(cart *entity.Cart) error
-	Delete(id uint) error
+	Delete(cartID uint) error
 	ConvertGuestCartToUserCart(sessionID string, userID uint) (*entity.Cart, error)
 }

--- a/internal/domain/repository/discount_repository.go
+++ b/internal/domain/repository/discount_repository.go
@@ -5,11 +5,11 @@ import "github.com/zenfulcode/commercify/internal/domain/entity"
 // DiscountRepository defines the interface for discount data access
 type DiscountRepository interface {
 	Create(discount *entity.Discount) error
-	GetByID(id uint) (*entity.Discount, error)
+	GetByID(discountID uint) (*entity.Discount, error)
 	GetByCode(code string) (*entity.Discount, error)
 	Update(discount *entity.Discount) error
-	Delete(id uint) error
+	Delete(discountID uint) error
 	List(offset, limit int) ([]*entity.Discount, error)
 	ListActive(offset, limit int) ([]*entity.Discount, error)
-	IncrementUsage(id uint) error
+	IncrementUsage(discountID uint) error
 }

--- a/internal/domain/repository/order_repository.go
+++ b/internal/domain/repository/order_repository.go
@@ -5,7 +5,7 @@ import "github.com/zenfulcode/commercify/internal/domain/entity"
 // OrderRepository defines the interface for order data access
 type OrderRepository interface {
 	Create(order *entity.Order) error
-	GetByID(id uint) (*entity.Order, error)
+	GetByID(orderID uint) (*entity.Order, error)
 	Update(order *entity.Order) error
 	GetByUser(userID uint, offset, limit int) ([]*entity.Order, error)
 	ListByStatus(status entity.OrderStatus, offset, limit int) ([]*entity.Order, error)

--- a/internal/domain/repository/product_repository.go
+++ b/internal/domain/repository/product_repository.go
@@ -5,10 +5,10 @@ import "github.com/zenfulcode/commercify/internal/domain/entity"
 // ProductRepository defines the interface for product data access
 type ProductRepository interface {
 	Create(product *entity.Product) error
-	GetByID(id uint) (*entity.Product, error)
-	GetByIDWithVariants(id uint) (*entity.Product, error)
+	GetByID(productID uint) (*entity.Product, error)
+	GetByIDWithVariants(productID uint) (*entity.Product, error)
 	Update(product *entity.Product) error
-	Delete(id uint) error
+	Delete(productID uint) error
 	List(offset, limit int) ([]*entity.Product, error)
 	// Search expects minPriceCents and maxPriceCents as int64 (cents)
 	Search(query string, categoryID uint, minPriceCents, maxPriceCents int64, offset, limit int) ([]*entity.Product, error)
@@ -21,9 +21,9 @@ type ProductRepository interface {
 // CategoryRepository defines the interface for category data access
 type CategoryRepository interface {
 	Create(category *entity.Category) error
-	GetByID(id uint) (*entity.Category, error)
+	GetByID(categoryID uint) (*entity.Category, error)
 	Update(category *entity.Category) error
-	Delete(id uint) error
+	Delete(categoryID uint) error
 	List() ([]*entity.Category, error)
 	GetChildren(parentID uint) ([]*entity.Category, error)
 }

--- a/internal/domain/repository/product_repository.go
+++ b/internal/domain/repository/product_repository.go
@@ -13,6 +13,9 @@ type ProductRepository interface {
 	// Search expects minPriceCents and maxPriceCents as int64 (cents)
 	Search(query string, categoryID uint, minPriceCents, maxPriceCents int64, offset, limit int) ([]*entity.Product, error)
 	GetBySeller(sellerID uint, offset, limit int) ([]*entity.Product, error)
+	Count() (int, error)
+	CountBySeller(sellerID uint) (int, error)
+	CountSearch(searchQuery string, categoryID uint, minPriceCents, maxPriceCents int64) (int, error)
 }
 
 // CategoryRepository defines the interface for category data access

--- a/internal/domain/repository/product_variant_repository.go
+++ b/internal/domain/repository/product_variant_repository.go
@@ -5,10 +5,10 @@ import "github.com/zenfulcode/commercify/internal/domain/entity"
 // ProductVariantRepository defines the interface for product variant data access
 type ProductVariantRepository interface {
 	Create(variant *entity.ProductVariant) error
-	GetByID(id uint) (*entity.ProductVariant, error)
+	GetByID(variantID uint) (*entity.ProductVariant, error)
 	GetBySKU(sku string) (*entity.ProductVariant, error)
 	GetByProduct(productID uint) ([]*entity.ProductVariant, error)
 	Update(variant *entity.ProductVariant) error
-	Delete(id uint) error
+	Delete(variantID uint) error
 	BatchCreate(variants []*entity.ProductVariant) error
 }

--- a/internal/domain/repository/shipping_repository.go
+++ b/internal/domain/repository/shipping_repository.go
@@ -5,25 +5,25 @@ import "github.com/zenfulcode/commercify/internal/domain/entity"
 // ShippingMethodRepository defines the interface for shipping method data access
 type ShippingMethodRepository interface {
 	Create(method *entity.ShippingMethod) error
-	GetByID(id uint) (*entity.ShippingMethod, error)
+	GetByID(methodID uint) (*entity.ShippingMethod, error)
 	List(active bool) ([]*entity.ShippingMethod, error)
 	Update(method *entity.ShippingMethod) error
-	Delete(id uint) error
+	Delete(methodID uint) error
 }
 
 // ShippingZoneRepository defines the interface for shipping zone data access
 type ShippingZoneRepository interface {
 	Create(zone *entity.ShippingZone) error
-	GetByID(id uint) (*entity.ShippingZone, error)
+	GetByID(zoneID uint) (*entity.ShippingZone, error)
 	List(active bool) ([]*entity.ShippingZone, error)
 	Update(zone *entity.ShippingZone) error
-	Delete(id uint) error
+	Delete(zoneID uint) error
 }
 
 // ShippingRateRepository defines the interface for shipping rate data access
 type ShippingRateRepository interface {
 	Create(rate *entity.ShippingRate) error
-	GetByID(id uint) (*entity.ShippingRate, error)
+	GetByID(rateID uint) (*entity.ShippingRate, error)
 	GetByMethodID(methodID uint) ([]*entity.ShippingRate, error)
 	GetByZoneID(zoneID uint) ([]*entity.ShippingRate, error)
 	GetAvailableRatesForAddress(address entity.Address, orderValue int64) ([]*entity.ShippingRate, error)
@@ -32,5 +32,5 @@ type ShippingRateRepository interface {
 	GetWeightBasedRates(rateID uint) ([]entity.WeightBasedRate, error)
 	GetValueBasedRates(rateID uint) ([]entity.ValueBasedRate, error)
 	Update(rate *entity.ShippingRate) error
-	Delete(id uint) error
+	Delete(rateID uint) error
 }

--- a/internal/domain/service/payment_service.go
+++ b/internal/domain/service/payment_service.go
@@ -96,4 +96,7 @@ type PaymentService interface {
 
 	// CancelPayment cancels a payment
 	CancelPayment(transactionID string, provider PaymentProviderType) error
+
+	// ForceApprovePayment force approves a payment
+	ForceApprovePayment(transactionID string, phoneNumber string, provider PaymentProviderType) error
 }

--- a/internal/infrastructure/container/repository_provider.go
+++ b/internal/infrastructure/container/repository_provider.go
@@ -32,8 +32,8 @@ type repositoryProvider struct {
 	mu        sync.Mutex
 
 	userRepo           repository.UserRepository
-	productRepo        repository.ProductRepository
 	productVariantRepo repository.ProductVariantRepository
+	productRepo        repository.ProductRepository
 	categoryRepo       repository.CategoryRepository
 	orderRepo          repository.OrderRepository
 	cartRepo           repository.CartRepository
@@ -71,7 +71,11 @@ func (p *repositoryProvider) ProductRepository() repository.ProductRepository {
 	defer p.mu.Unlock()
 
 	if p.productRepo == nil {
-		p.productRepo = postgres.NewProductRepository(p.container.DB())
+		// Initialize both repositories under the same lock
+		if p.productVariantRepo == nil {
+			p.productVariantRepo = postgres.NewProductVariantRepository(p.container.DB())
+		}
+		p.productRepo = postgres.NewProductRepository(p.container.DB(), p.productVariantRepo)
 	}
 	return p.productRepo
 }

--- a/internal/infrastructure/payment/mobilepay_payment_service.go
+++ b/internal/infrastructure/payment/mobilepay_payment_service.go
@@ -219,6 +219,28 @@ func (s *MobilePayPaymentService) CancelPayment(transactionID string, provider s
 	return nil
 }
 
+func (s *MobilePayPaymentService) ForceApprovePayment(transactionID string, phoneNumber string, provider service.PaymentProviderType) error {
+	if provider != service.PaymentProviderMobilePay {
+		return errors.New("invalid payment provider")
+	}
+
+	if transactionID == "" {
+		return errors.New("transaction ID is required")
+	}
+
+	if phoneNumber == "" {
+		return errors.New("phone number is required")
+	}
+
+	err := s.epayment.ForceApprove(transactionID, phoneNumber)
+
+	if err != nil {
+		return fmt.Errorf("failed to force approve payment: %v", err)
+	}
+
+	return nil
+}
+
 func (s *MobilePayPaymentService) GetAccessToken() error {
 	err := s.vippsClient.EnsureValidToken()
 	if err != nil {

--- a/internal/infrastructure/payment/mock_payment_service.go
+++ b/internal/infrastructure/payment/mock_payment_service.go
@@ -160,3 +160,7 @@ func (s *MockPaymentService) CancelPayment(transactionID string, provider servic
 	// Always succeed for mock service
 	return nil
 }
+
+func (s *MockPaymentService) ForceApprovePayment(transactionID string, phoneNumber string, provider service.PaymentProviderType) error {
+	return nil
+}

--- a/internal/infrastructure/payment/multi_provider_payment_service.go
+++ b/internal/infrastructure/payment/multi_provider_payment_service.go
@@ -185,3 +185,12 @@ func (s *MultiProviderPaymentService) CancelPayment(transactionID string, provid
 func contains(slice []string, item string) bool {
 	return slices.Contains(slice, item)
 }
+
+func (s *MultiProviderPaymentService) ForceApprovePayment(transactionID string, phoneNumber string, provider service.PaymentProviderType) error {
+	paymentProvider, exists := s.providers[provider]
+	if !exists {
+		return fmt.Errorf("payment provider %s not available", provider)
+	}
+
+	return paymentProvider.ForceApprovePayment(transactionID, phoneNumber, provider)
+}

--- a/internal/infrastructure/payment/stripe_payment_service.go
+++ b/internal/infrastructure/payment/stripe_payment_service.go
@@ -360,6 +360,10 @@ func (s *StripePaymentService) CancelPayment(transactionID string, provider serv
 	return nil
 }
 
+func (s *StripePaymentService) ForceApprovePayment(transactionID string, phoneNumber string, provider service.PaymentProviderType) error {
+	return errors.New("not implemented")
+}
+
 // CreateSetupIntent creates a setup intent for saving a payment method without charging
 func (s *StripePaymentService) CreateSetupIntent(customerEmail string) (string, string, error) {
 	// This method could be used to save payment methods for future use

--- a/internal/infrastructure/repository/postgres/cart_repository.go
+++ b/internal/infrastructure/repository/postgres/cart_repository.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/zenfulcode/commercify/internal/domain/entity"
+	"github.com/zenfulcode/commercify/internal/domain/repository"
 )
 
 // CartRepository implements the cart repository interface using PostgreSQL
@@ -14,7 +15,7 @@ type CartRepository struct {
 }
 
 // NewCartRepository creates a new CartRepository
-func NewCartRepository(db *sql.DB) *CartRepository {
+func NewCartRepository(db *sql.DB) repository.CartRepository {
 	return &CartRepository{db: db}
 }
 

--- a/internal/infrastructure/repository/postgres/cart_repository.go
+++ b/internal/infrastructure/repository/postgres/cart_repository.go
@@ -278,9 +278,9 @@ func (r *CartRepository) Update(cart *entity.Cart) error {
 }
 
 // Delete deletes a cart
-func (r *CartRepository) Delete(id uint) error {
+func (r *CartRepository) Delete(cartID uint) error {
 	query := `DELETE FROM carts WHERE id = $1`
-	_, err := r.db.Exec(query, id)
+	_, err := r.db.Exec(query, cartID)
 	return err
 }
 

--- a/internal/infrastructure/repository/postgres/category_repository.go
+++ b/internal/infrastructure/repository/postgres/category_repository.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/zenfulcode/commercify/internal/domain/entity"
+	"github.com/zenfulcode/commercify/internal/domain/repository"
 )
 
 // CategoryRepository implements the category repository interface using PostgreSQL
@@ -14,7 +15,7 @@ type CategoryRepository struct {
 }
 
 // NewCategoryRepository creates a new CategoryRepository
-func NewCategoryRepository(db *sql.DB) *CategoryRepository {
+func NewCategoryRepository(db *sql.DB) repository.CategoryRepository {
 	return &CategoryRepository{db: db}
 }
 

--- a/internal/infrastructure/repository/postgres/discount_repository.go
+++ b/internal/infrastructure/repository/postgres/discount_repository.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/zenfulcode/commercify/internal/domain/entity"
+	"github.com/zenfulcode/commercify/internal/domain/repository"
 )
 
 // DiscountRepository implements the discount repository interface using PostgreSQL
@@ -15,7 +16,7 @@ type DiscountRepository struct {
 }
 
 // NewDiscountRepository creates a new DiscountRepository
-func NewDiscountRepository(db *sql.DB) *DiscountRepository {
+func NewDiscountRepository(db *sql.DB) repository.DiscountRepository {
 	return &DiscountRepository{db: db}
 }
 

--- a/internal/infrastructure/repository/postgres/discount_repository.go
+++ b/internal/infrastructure/repository/postgres/discount_repository.go
@@ -65,7 +65,7 @@ func (r *DiscountRepository) Create(discount *entity.Discount) error {
 }
 
 // GetByID retrieves a discount by ID
-func (r *DiscountRepository) GetByID(id uint) (*entity.Discount, error) {
+func (r *DiscountRepository) GetByID(discountID uint) (*entity.Discount, error) {
 	query := `
 		SELECT id, code, type, method, value, min_order_value, max_discount_value, 
 			product_ids, category_ids, start_date, end_date, 
@@ -77,7 +77,7 @@ func (r *DiscountRepository) GetByID(id uint) (*entity.Discount, error) {
 	var productIDsJSON, categoryIDsJSON []byte
 	discount := &entity.Discount{}
 
-	err := r.db.QueryRow(query, id).Scan(
+	err := r.db.QueryRow(query, discountID).Scan(
 		&discount.ID,
 		&discount.Code,
 		&discount.Type,
@@ -214,9 +214,9 @@ func (r *DiscountRepository) Update(discount *entity.Discount) error {
 }
 
 // Delete deletes a discount
-func (r *DiscountRepository) Delete(id uint) error {
+func (r *DiscountRepository) Delete(discountID uint) error {
 	query := `DELETE FROM discounts WHERE id = $1`
-	_, err := r.db.Exec(query, id)
+	_, err := r.db.Exec(query, discountID)
 	return err
 }
 
@@ -345,13 +345,13 @@ func (r *DiscountRepository) ListActive(offset, limit int) ([]*entity.Discount, 
 }
 
 // IncrementUsage increments the usage count of a discount
-func (r *DiscountRepository) IncrementUsage(id uint) error {
+func (r *DiscountRepository) IncrementUsage(discountID uint) error {
 	query := `
 		UPDATE discounts
 		SET current_usage = current_usage + 1, updated_at = $1
 		WHERE id = $2
 	`
 
-	_, err := r.db.Exec(query, time.Now(), id)
+	_, err := r.db.Exec(query, time.Now(), discountID)
 	return err
 }

--- a/internal/infrastructure/repository/postgres/order_repository.go
+++ b/internal/infrastructure/repository/postgres/order_repository.go
@@ -159,7 +159,7 @@ func (r *OrderRepository) Create(order *entity.Order) error {
 }
 
 // GetByID retrieves an order by ID
-func (r *OrderRepository) GetByID(id uint) (*entity.Order, error) {
+func (r *OrderRepository) GetByID(orderID uint) (*entity.Order, error) {
 	// Get order
 	query := `
 		SELECT id, order_number, user_id, total_amount, status, shipping_address, billing_address,
@@ -187,7 +187,7 @@ func (r *OrderRepository) GetByID(id uint) (*entity.Order, error) {
 	var discountID sql.NullInt64
 	var discountCode sql.NullString
 
-	err := r.db.QueryRow(query, id).Scan(
+	err := r.db.QueryRow(query, orderID).Scan(
 		&order.ID,
 		&orderNumber,
 		&userID,

--- a/internal/infrastructure/repository/postgres/order_repository.go
+++ b/internal/infrastructure/repository/postgres/order_repository.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/zenfulcode/commercify/internal/domain/entity"
+	"github.com/zenfulcode/commercify/internal/domain/repository"
 )
 
 // OrderRepository implements the order repository interface using PostgreSQL
@@ -15,7 +16,7 @@ type OrderRepository struct {
 }
 
 // NewOrderRepository creates a new OrderRepository
-func NewOrderRepository(db *sql.DB) *OrderRepository {
+func NewOrderRepository(db *sql.DB) repository.OrderRepository {
 	return &OrderRepository{db: db}
 }
 

--- a/internal/infrastructure/repository/postgres/order_repository.go
+++ b/internal/infrastructure/repository/postgres/order_repository.go
@@ -56,9 +56,10 @@ func (r *OrderRepository) Create(order *entity.Order) error {
 			INSERT INTO orders (
 				user_id, total_amount, status, shipping_address, billing_address,
 				payment_id, payment_provider, tracking_code, created_at, updated_at, completed_at, final_amount,
-				guest_email, guest_phone, guest_full_name, is_guest_order
+				guest_email, guest_phone, guest_full_name, is_guest_order, shipping_method_id, shipping_cost,
+				total_weight
 			)
-			VALUES (NULL, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+			VALUES (NULL, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
 			RETURNING id
 		`
 
@@ -79,15 +80,19 @@ func (r *OrderRepository) Create(order *entity.Order) error {
 			order.GuestPhone,
 			order.GuestFullName,
 			order.IsGuestOrder,
+			order.ShippingMethodID,
+			order.ShippingCost,
+			order.TotalWeight,
 		).Scan(&order.ID)
 	} else {
 		// Regular user order
 		query = `
 			INSERT INTO orders (
 				user_id, total_amount, status, shipping_address, billing_address,
-				payment_id, payment_provider, tracking_code, created_at, updated_at, completed_at, final_amount
+				payment_id, payment_provider, tracking_code, created_at, updated_at, completed_at, final_amount,
+				shipping_method_id, shipping_cost, total_weight
 			)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
 			RETURNING id
 		`
 
@@ -105,6 +110,9 @@ func (r *OrderRepository) Create(order *entity.Order) error {
 			order.UpdatedAt,
 			order.CompletedAt,
 			order.FinalAmount,
+			order.ShippingMethodID,
+			order.ShippingCost,
+			order.TotalWeight,
 		).Scan(&order.ID)
 	}
 
@@ -157,7 +165,8 @@ func (r *OrderRepository) GetByID(id uint) (*entity.Order, error) {
 		SELECT id, order_number, user_id, total_amount, status, shipping_address, billing_address,
 			payment_id, payment_provider, tracking_code, created_at, updated_at, completed_at,
 			discount_amount, discount_id, discount_code, final_amount, action_url,
-			guest_email, guest_phone, guest_full_name, is_guest_order
+			guest_email, guest_phone, guest_full_name, is_guest_order, shipping_method_id, shipping_cost,
+			total_weight
 		FROM orders
 		WHERE id = $1
 	`
@@ -171,6 +180,9 @@ func (r *OrderRepository) GetByID(id uint) (*entity.Order, error) {
 	var userID sql.NullInt64 // Use NullInt64 to handle NULL user_id
 	var guestEmail, guestPhone, guestFullName sql.NullString
 	var isGuestOrder sql.NullBool
+	var shippingMethodID sql.NullInt64
+	var shippingCost sql.NullInt64
+	var totalWeight sql.NullFloat64
 
 	var discountID sql.NullInt64
 	var discountCode sql.NullString
@@ -198,6 +210,9 @@ func (r *OrderRepository) GetByID(id uint) (*entity.Order, error) {
 		&guestPhone,
 		&guestFullName,
 		&isGuestOrder,
+		&shippingMethodID,
+		&shippingCost,
+		&totalWeight,
 	)
 
 	if err == sql.ErrNoRows {
@@ -268,6 +283,21 @@ func (r *OrderRepository) GetByID(id uint) (*entity.Order, error) {
 		order.CompletedAt = &completedAt.Time
 	}
 
+	// Set shipping method ID if valid
+	if shippingMethodID.Valid {
+		order.ShippingMethodID = uint(shippingMethodID.Int64)
+	}
+
+	// Set shipping cost if valid
+	if shippingCost.Valid {
+		order.ShippingCost = shippingCost.Int64
+	}
+
+	// Set total weight if valid
+	if totalWeight.Valid {
+		order.TotalWeight = totalWeight.Float64
+	}
+
 	// Get order items
 	query = `
 		SELECT id, order_id, product_id, quantity, price, subtotal
@@ -323,8 +353,11 @@ func (r *OrderRepository) Update(order *entity.Order) error {
 			discount_id = $11,
 			discount_amount = $12,
 			discount_code = $13,
-			action_url = $14
-		WHERE id = $15
+			action_url = $14,
+			shipping_method_id = $15,
+			shipping_cost = $16,
+			total_weight = $17
+		WHERE id = $18
 	`
 
 	var discountID sql.NullInt64
@@ -355,6 +388,9 @@ func (r *OrderRepository) Update(order *entity.Order) error {
 		discountAmount,
 		discountCode,
 		order.ActionURL,
+		order.ShippingMethodID,
+		order.ShippingCost,
+		order.TotalWeight,
 		order.ID,
 	)
 

--- a/internal/infrastructure/repository/postgres/product_repository.go
+++ b/internal/infrastructure/repository/postgres/product_repository.go
@@ -112,7 +112,7 @@ func (r *ProductRepository) createProductPrice(price *entity.ProductPrice) error
 }
 
 // GetByID gets a product by ID
-func (r *ProductRepository) GetByID(id uint) (*entity.Product, error) {
+func (r *ProductRepository) GetByID(productID uint) (*entity.Product, error) {
 	query := `
 			SELECT id, product_number, name, description, price, stock, weight, category_id, seller_id, images, has_variants, created_at, updated_at
 			FROM products
@@ -123,7 +123,7 @@ func (r *ProductRepository) GetByID(id uint) (*entity.Product, error) {
 	product := &entity.Product{}
 	var productNumber sql.NullString
 
-	err := r.db.QueryRow(query, id).Scan(
+	err := r.db.QueryRow(query, productID).Scan(
 		&product.ID,
 		&productNumber,
 		&product.Name,
@@ -212,16 +212,16 @@ func (r *ProductRepository) getProductPrices(productID uint) ([]entity.ProductPr
 }
 
 // GetByIDWithVariants gets a product by ID with variants
-func (r *ProductRepository) GetByIDWithVariants(productId uint) (*entity.Product, error) {
+func (r *ProductRepository) GetByIDWithVariants(productID uint) (*entity.Product, error) {
 	// Get the base product
-	product, err := r.GetByID(productId)
+	product, err := r.GetByID(productID)
 	if err != nil {
 		return nil, err
 	}
 
 	// If product has variants, get them
 	if product.HasVariants {
-		variants, err := r.variantRepository.GetByProduct(productId)
+		variants, err := r.variantRepository.GetByProduct(productID)
 		if err != nil {
 			return nil, err
 		}
@@ -284,7 +284,7 @@ func (r *ProductRepository) Update(product *entity.Product) error {
 }
 
 // Delete deletes a product
-func (r *ProductRepository) Delete(id uint) error {
+func (r *ProductRepository) Delete(productID uint) error {
 	// Start a transaction to delete variants as well
 	tx, err := r.db.Begin()
 	if err != nil {
@@ -297,13 +297,13 @@ func (r *ProductRepository) Delete(id uint) error {
 	}()
 
 	// Delete variants first
-	_, err = tx.Exec("DELETE FROM product_variants WHERE product_id = $1", id)
+	_, err = tx.Exec("DELETE FROM product_variants WHERE product_id = $1", productID)
 	if err != nil {
 		return err
 	}
 
 	// Delete the product
-	_, err = tx.Exec("DELETE FROM products WHERE id = $1", id)
+	_, err = tx.Exec("DELETE FROM products WHERE id = $1", productID)
 	if err != nil {
 		return err
 	}

--- a/internal/infrastructure/repository/postgres/product_variant_repository.go
+++ b/internal/infrastructure/repository/postgres/product_variant_repository.go
@@ -129,7 +129,7 @@ func (r *ProductVariantRepository) createVariantPrice(price *entity.ProductVaria
 }
 
 // GetByID gets a variant by ID
-func (r *ProductVariantRepository) GetByID(id uint) (*entity.ProductVariant, error) {
+func (r *ProductVariantRepository) GetByID(variantID uint) (*entity.ProductVariant, error) {
 	query := `
 		SELECT id, product_id, sku, price, compare_price, stock, attributes, images, is_default, created_at, updated_at
 		FROM product_variants
@@ -140,7 +140,7 @@ func (r *ProductVariantRepository) GetByID(id uint) (*entity.ProductVariant, err
 	variant := &entity.ProductVariant{}
 	var comparePrice sql.NullInt64
 
-	err := r.db.QueryRow(query, id).Scan(
+	err := r.db.QueryRow(query, variantID).Scan(
 		&variant.ID,
 		&variant.ProductID,
 		&variant.SKU,
@@ -309,7 +309,7 @@ func (r *ProductVariantRepository) Update(variant *entity.ProductVariant) error 
 }
 
 // Delete deletes a product variant
-func (r *ProductVariantRepository) Delete(id uint) error {
+func (r *ProductVariantRepository) Delete(variantID uint) error {
 	// Check if this is the only variant or if it's the default variant
 	var isDefault bool
 	var productID uint
@@ -318,7 +318,7 @@ func (r *ProductVariantRepository) Delete(id uint) error {
 	// First verify the variant exists and get its product ID
 	err := r.db.QueryRow(
 		"SELECT is_default, product_id FROM product_variants WHERE id = $1",
-		id,
+		variantID,
 	).Scan(&isDefault, &productID)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -348,7 +348,7 @@ func (r *ProductVariantRepository) Delete(id uint) error {
 	}()
 
 	// Delete the variant
-	result, err := tx.Exec("DELETE FROM product_variants WHERE id = $1", id)
+	result, err := tx.Exec("DELETE FROM product_variants WHERE id = $1", variantID)
 	if err != nil {
 		return err
 	}
@@ -384,7 +384,7 @@ func (r *ProductVariantRepository) Delete(id uint) error {
 				ORDER BY id ASC 
 				LIMIT 1
 			)
-		`, productID, id)
+		`, productID, variantID)
 		if err != nil {
 			return err
 		}

--- a/internal/infrastructure/repository/postgres/shipping_method_repository.go
+++ b/internal/infrastructure/repository/postgres/shipping_method_repository.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/zenfulcode/commercify/internal/domain/entity"
+	"github.com/zenfulcode/commercify/internal/domain/repository"
 )
 
 // ShippingMethodRepository implements the shipping method repository interface using PostgreSQL
@@ -14,7 +15,7 @@ type ShippingMethodRepository struct {
 }
 
 // NewShippingMethodRepository creates a new ShippingMethodRepository
-func NewShippingMethodRepository(db *sql.DB) *ShippingMethodRepository {
+func NewShippingMethodRepository(db *sql.DB) repository.ShippingMethodRepository {
 	return &ShippingMethodRepository{db: db}
 }
 

--- a/internal/infrastructure/repository/postgres/shipping_method_repository.go
+++ b/internal/infrastructure/repository/postgres/shipping_method_repository.go
@@ -41,7 +41,7 @@ func (r *ShippingMethodRepository) Create(method *entity.ShippingMethod) error {
 }
 
 // GetByID retrieves a shipping method by ID
-func (r *ShippingMethodRepository) GetByID(id uint) (*entity.ShippingMethod, error) {
+func (r *ShippingMethodRepository) GetByID(methodID uint) (*entity.ShippingMethod, error) {
 	query := `
 		SELECT id, name, description, estimated_delivery_days, active, created_at, updated_at
 		FROM shipping_methods
@@ -49,7 +49,7 @@ func (r *ShippingMethodRepository) GetByID(id uint) (*entity.ShippingMethod, err
 	`
 
 	method := &entity.ShippingMethod{}
-	err := r.db.QueryRow(query, id).Scan(
+	err := r.db.QueryRow(query, methodID).Scan(
 		&method.ID,
 		&method.Name,
 		&method.Description,
@@ -141,8 +141,8 @@ func (r *ShippingMethodRepository) Update(method *entity.ShippingMethod) error {
 }
 
 // Delete deletes a shipping method
-func (r *ShippingMethodRepository) Delete(id uint) error {
+func (r *ShippingMethodRepository) Delete(methodID uint) error {
 	query := `DELETE FROM shipping_methods WHERE id = $1`
-	_, err := r.db.Exec(query, id)
+	_, err := r.db.Exec(query, methodID)
 	return err
 }

--- a/internal/infrastructure/repository/postgres/shipping_rate_repository.go
+++ b/internal/infrastructure/repository/postgres/shipping_rate_repository.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/zenfulcode/commercify/internal/domain/entity"
+	"github.com/zenfulcode/commercify/internal/domain/repository"
 )
 
 // ShippingRateRepository implements the shipping rate repository interface using PostgreSQL
@@ -18,7 +19,7 @@ type ShippingRateRepository struct {
 }
 
 // NewShippingRateRepository creates a new ShippingRateRepository
-func NewShippingRateRepository(db *sql.DB) *ShippingRateRepository {
+func NewShippingRateRepository(db *sql.DB) repository.ShippingRateRepository {
 	return &ShippingRateRepository{db: db}
 }
 

--- a/internal/infrastructure/repository/postgres/shipping_rate_repository.go
+++ b/internal/infrastructure/repository/postgres/shipping_rate_repository.go
@@ -54,7 +54,7 @@ func (r *ShippingRateRepository) Create(rate *entity.ShippingRate) error {
 }
 
 // GetByID retrieves a shipping rate by ID
-func (r *ShippingRateRepository) GetByID(id uint) (*entity.ShippingRate, error) {
+func (r *ShippingRateRepository) GetByID(rateID uint) (*entity.ShippingRate, error) {
 	// First, get the basic shipping rate data
 	query := `
 		SELECT id, shipping_method_id, shipping_zone_id, base_rate, min_order_value, 
@@ -69,7 +69,7 @@ func (r *ShippingRateRepository) GetByID(id uint) (*entity.ShippingRate, error) 
 		ShippingZone:   &entity.ShippingZone{},
 	}
 
-	err := r.db.QueryRow(query, id).Scan(
+	err := r.db.QueryRow(query, rateID).Scan(
 		&rate.ID,
 		&rate.ShippingMethodID,
 		&rate.ShippingZoneID,
@@ -548,7 +548,7 @@ func (r *ShippingRateRepository) Update(rate *entity.ShippingRate) error {
 }
 
 // Delete deletes a shipping rate
-func (r *ShippingRateRepository) Delete(id uint) error {
+func (r *ShippingRateRepository) Delete(rateID uint) error {
 	// Start a transaction to delete related records as well
 	tx, err := r.db.Begin()
 	if err != nil {
@@ -561,19 +561,19 @@ func (r *ShippingRateRepository) Delete(id uint) error {
 	}()
 
 	// Delete weight-based rates first
-	_, err = tx.Exec("DELETE FROM weight_based_rates WHERE shipping_rate_id = $1", id)
+	_, err = tx.Exec("DELETE FROM weight_based_rates WHERE shipping_rate_id = $1", rateID)
 	if err != nil {
 		return err
 	}
 
 	// Delete value-based rates
-	_, err = tx.Exec("DELETE FROM value_based_rates WHERE shipping_rate_id = $1", id)
+	_, err = tx.Exec("DELETE FROM value_based_rates WHERE shipping_rate_id = $1", rateID)
 	if err != nil {
 		return err
 	}
 
 	// Delete the shipping rate itself
-	_, err = tx.Exec("DELETE FROM shipping_rates WHERE id = $1", id)
+	_, err = tx.Exec("DELETE FROM shipping_rates WHERE id = $1", rateID)
 	if err != nil {
 		return err
 	}

--- a/internal/infrastructure/repository/postgres/shipping_zone_repository.go
+++ b/internal/infrastructure/repository/postgres/shipping_zone_repository.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/zenfulcode/commercify/internal/domain/entity"
+	"github.com/zenfulcode/commercify/internal/domain/repository"
 )
 
 // ShippingZoneRepository implements the shipping zone repository interface using PostgreSQL
@@ -15,7 +16,7 @@ type ShippingZoneRepository struct {
 }
 
 // NewShippingZoneRepository creates a new ShippingZoneRepository
-func NewShippingZoneRepository(db *sql.DB) *ShippingZoneRepository {
+func NewShippingZoneRepository(db *sql.DB) repository.ShippingZoneRepository {
 	return &ShippingZoneRepository{db: db}
 }
 

--- a/internal/infrastructure/repository/postgres/shipping_zone_repository.go
+++ b/internal/infrastructure/repository/postgres/shipping_zone_repository.go
@@ -59,7 +59,7 @@ func (r *ShippingZoneRepository) Create(zone *entity.ShippingZone) error {
 }
 
 // GetByID retrieves a shipping zone by ID
-func (r *ShippingZoneRepository) GetByID(id uint) (*entity.ShippingZone, error) {
+func (r *ShippingZoneRepository) GetByID(zoneID uint) (*entity.ShippingZone, error) {
 	query := `
 		SELECT id, name, description, countries, states, zip_codes, active, created_at, updated_at
 		FROM shipping_zones
@@ -68,7 +68,7 @@ func (r *ShippingZoneRepository) GetByID(id uint) (*entity.ShippingZone, error) 
 
 	var countriesJSON, statesJSON, zipCodesJSON []byte
 	zone := &entity.ShippingZone{}
-	err := r.db.QueryRow(query, id).Scan(
+	err := r.db.QueryRow(query, zoneID).Scan(
 		&zone.ID,
 		&zone.Name,
 		&zone.Description,
@@ -210,8 +210,8 @@ func (r *ShippingZoneRepository) Update(zone *entity.ShippingZone) error {
 }
 
 // Delete deletes a shipping zone
-func (r *ShippingZoneRepository) Delete(id uint) error {
+func (r *ShippingZoneRepository) Delete(zoneID uint) error {
 	query := `DELETE FROM shipping_zones WHERE id = $1`
-	_, err := r.db.Exec(query, id)
+	_, err := r.db.Exec(query, zoneID)
 	return err
 }

--- a/internal/infrastructure/repository/postgres/user_repository.go
+++ b/internal/infrastructure/repository/postgres/user_repository.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/zenfulcode/commercify/internal/domain/entity"
+	"github.com/zenfulcode/commercify/internal/domain/repository"
 )
 
 // UserRepository implements the user repository interface using PostgreSQL
@@ -14,7 +15,7 @@ type UserRepository struct {
 }
 
 // NewUserRepository creates a new UserRepository
-func NewUserRepository(db *sql.DB) *UserRepository {
+func NewUserRepository(db *sql.DB) repository.UserRepository {
 	return &UserRepository{db: db}
 }
 

--- a/internal/infrastructure/repository/postgres/webhook_repository.go
+++ b/internal/infrastructure/repository/postgres/webhook_repository.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/zenfulcode/commercify/internal/domain/entity"
+	"github.com/zenfulcode/commercify/internal/domain/repository"
 )
 
 // WebhookRepository implements the WebhookRepository interface using PostgreSQL
@@ -15,7 +16,7 @@ type WebhookRepository struct {
 }
 
 // NewWebhookRepository creates a new WebhookRepository
-func NewWebhookRepository(db *sql.DB) *WebhookRepository {
+func NewWebhookRepository(db *sql.DB) repository.WebhookRepository {
 	return &WebhookRepository{
 		db: db,
 	}

--- a/internal/interfaces/api/handler/order_handler.go
+++ b/internal/interfaces/api/handler/order_handler.go
@@ -94,7 +94,7 @@ func (h *OrderHandler) GetOrder(w http.ResponseWriter, r *http.Request) {
 
 	// Get order ID from URL
 	vars := mux.Vars(r)
-	id, err := strconv.ParseUint(vars["id"], 10, 32)
+	id, err := strconv.ParseUint(vars["orderId"], 10, 32)
 	if err != nil {
 		http.Error(w, "Invalid order ID", http.StatusBadRequest)
 		return
@@ -155,7 +155,7 @@ func (h *OrderHandler) ListOrders(w http.ResponseWriter, r *http.Request) {
 func (h *OrderHandler) ProcessPayment(w http.ResponseWriter, r *http.Request) {
 	// Get order ID from URL
 	vars := mux.Vars(r)
-	id, err := strconv.ParseUint(vars["id"], 10, 32)
+	id, err := strconv.ParseUint(vars["orderId"], 10, 32)
 	if err != nil {
 		http.Error(w, "Invalid order ID", http.StatusBadRequest)
 		return
@@ -309,7 +309,7 @@ func (h *OrderHandler) ListAllOrders(w http.ResponseWriter, r *http.Request) {
 func (h *OrderHandler) UpdateOrderStatus(w http.ResponseWriter, r *http.Request) {
 	// Get order ID from URL
 	vars := mux.Vars(r)
-	id, err := strconv.ParseUint(vars["id"], 10, 32)
+	id, err := strconv.ParseUint(vars["orderId"], 10, 32)
 	if err != nil {
 		http.Error(w, "Invalid order ID", http.StatusBadRequest)
 		return

--- a/internal/interfaces/api/handler/order_handler.go
+++ b/internal/interfaces/api/handler/order_handler.go
@@ -36,6 +36,12 @@ func (h *OrderHandler) CreateOrder(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Validate shipping method ID
+	if input.ShippingMethodID == 0 {
+		http.Error(w, "Shipping method ID is required", http.StatusBadRequest)
+		return
+	}
+
 	// Check if user is authenticated
 	userID, ok := r.Context().Value("user_id").(uint)
 

--- a/internal/interfaces/api/handler/order_handler.go
+++ b/internal/interfaces/api/handler/order_handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/zenfulcode/commercify/internal/application/usecase"
+	"github.com/zenfulcode/commercify/internal/domain/common"
 	"github.com/zenfulcode/commercify/internal/domain/entity"
 	"github.com/zenfulcode/commercify/internal/domain/service"
 	"github.com/zenfulcode/commercify/internal/infrastructure/logger"
@@ -48,7 +49,7 @@ func (h *OrderHandler) CreateOrder(w http.ResponseWriter, r *http.Request) {
 	} else {
 		// Guest checkout
 		// Get session ID from cookie
-		cookie, cookieErr := r.Cookie(sessionCookieName)
+		cookie, cookieErr := r.Cookie(common.SessionCookieName)
 		if cookieErr != nil || cookie.Value == "" {
 			http.Error(w, "No cart session found", http.StatusBadRequest)
 			return
@@ -198,7 +199,7 @@ func (h *OrderHandler) ProcessPayment(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Only allow payment processing for guest orders if they have a valid cookie
-		cookie, cookieErr := r.Cookie(sessionCookieName)
+		cookie, cookieErr := r.Cookie(common.SessionCookieName)
 		if cookieErr != nil || cookie.Value == "" {
 			http.Error(w, "Invalid session", http.StatusUnauthorized)
 			return

--- a/internal/interfaces/api/handler/product_handler.go
+++ b/internal/interfaces/api/handler/product_handler.go
@@ -210,7 +210,7 @@ func (h *ProductHandler) UpdateProduct(w http.ResponseWriter, r *http.Request) {
 
 	// Get product ID from URL
 	vars := mux.Vars(r)
-	id, err := strconv.ParseUint(vars["id"], 10, 32)
+	id, err := strconv.ParseUint(vars["productId"], 10, 32)
 	if err != nil {
 		http.Error(w, "Invalid product ID", http.StatusBadRequest)
 		return
@@ -254,7 +254,7 @@ func (h *ProductHandler) DeleteProduct(w http.ResponseWriter, r *http.Request) {
 
 	// Get product ID from URL
 	vars := mux.Vars(r)
-	id, err := strconv.ParseUint(vars["id"], 10, 32)
+	id, err := strconv.ParseUint(vars["productId"], 10, 32)
 	if err != nil {
 		http.Error(w, "Invalid product ID", http.StatusBadRequest)
 		return

--- a/internal/interfaces/api/handler/shipping_handler.go
+++ b/internal/interfaces/api/handler/shipping_handler.go
@@ -125,7 +125,7 @@ func (h *ShippingHandler) CreateShippingMethod(w http.ResponseWriter, r *http.Re
 func (h *ShippingHandler) UpdateShippingMethod(w http.ResponseWriter, r *http.Request) {
 	// Get method ID from URL
 	vars := mux.Vars(r)
-	id, err := strconv.ParseUint(vars["id"], 10, 32)
+	id, err := strconv.ParseUint(vars["shippingMethodId"], 10, 32)
 	if err != nil {
 		http.Error(w, "Invalid shipping method ID", http.StatusBadRequest)
 		return
@@ -181,7 +181,7 @@ func (h *ShippingHandler) CreateShippingZone(w http.ResponseWriter, r *http.Requ
 func (h *ShippingHandler) GetShippingZoneByID(w http.ResponseWriter, r *http.Request) {
 	// Get zone ID from URL
 	vars := mux.Vars(r)
-	id, err := strconv.ParseUint(vars["id"], 10, 32)
+	id, err := strconv.ParseUint(vars["shippingZoneId"], 10, 32)
 	if err != nil {
 		http.Error(w, "Invalid shipping zone ID", http.StatusBadRequest)
 		return
@@ -222,7 +222,7 @@ func (h *ShippingHandler) ListShippingZones(w http.ResponseWriter, r *http.Reque
 func (h *ShippingHandler) UpdateShippingZone(w http.ResponseWriter, r *http.Request) {
 	// Get zone ID from URL
 	vars := mux.Vars(r)
-	id, err := strconv.ParseUint(vars["id"], 10, 32)
+	id, err := strconv.ParseUint(vars["shippingZoneId"], 10, 32)
 	if err != nil {
 		http.Error(w, "Invalid shipping zone ID", http.StatusBadRequest)
 		return
@@ -278,7 +278,7 @@ func (h *ShippingHandler) CreateShippingRate(w http.ResponseWriter, r *http.Requ
 func (h *ShippingHandler) GetShippingRateByID(w http.ResponseWriter, r *http.Request) {
 	// Get rate ID from URL
 	vars := mux.Vars(r)
-	id, err := strconv.ParseUint(vars["id"], 10, 32)
+	id, err := strconv.ParseUint(vars["shippingRateId"], 10, 32)
 	if err != nil {
 		http.Error(w, "Invalid shipping rate ID", http.StatusBadRequest)
 		return
@@ -301,7 +301,7 @@ func (h *ShippingHandler) GetShippingRateByID(w http.ResponseWriter, r *http.Req
 func (h *ShippingHandler) UpdateShippingRate(w http.ResponseWriter, r *http.Request) {
 	// Get rate ID from URL
 	vars := mux.Vars(r)
-	id, err := strconv.ParseUint(vars["id"], 10, 32)
+	id, err := strconv.ParseUint(vars["shippingRateId"], 10, 32)
 	if err != nil {
 		http.Error(w, "Invalid shipping rate ID", http.StatusBadRequest)
 		return

--- a/internal/interfaces/api/handler/webhook_handler.go
+++ b/internal/interfaces/api/handler/webhook_handler.go
@@ -179,7 +179,6 @@ func (h *WebhookHandler) HandleMobilePayAuthorized(event *models.WebhookEvent) e
 	err = h.recordMobilePayPaymentTransaction(order, entity.TransactionStatusSuccessful, event)
 	if err != nil {
 		h.logger.Error("Failed to record payment transaction: %v", err)
-		return err
 	}
 
 	h.logger.Info("MobilePay payment authorized for order %d", orderID)
@@ -456,7 +455,6 @@ func (h *WebhookHandler) handlePaymentSucceeded(event stripe.Event) {
 		err = h.orderUseCase.RecordPaymentTransaction(txn)
 		if err != nil {
 			h.logger.Error("Failed to record payment transaction: %v", err)
-			// Continue processing even if transaction recording fails
 		}
 	}
 

--- a/internal/interfaces/api/pagination/pagination.go
+++ b/internal/interfaces/api/pagination/pagination.go
@@ -1,0 +1,93 @@
+package pagination
+
+import (
+	"net/http"
+	"strconv"
+)
+
+// DefaultLimit is the default number of items to return per page
+const DefaultLimit = 10
+
+// PaginationParams contains the pagination parameters
+type PaginationParams struct {
+	Offset int
+	Limit  int
+	Page   int
+}
+
+// ParsePaginationParams extracts pagination parameters from the request
+func ParsePaginationParams(r *http.Request) PaginationParams {
+	// Parse offset parameter
+	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+
+	// Parse limit parameter with default value
+	limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
+	if err != nil || limit <= 0 {
+		limit = DefaultLimit
+	}
+
+	// Parse page parameter (alternative to offset)
+	page, err := strconv.Atoi(r.URL.Query().Get("page"))
+	if err != nil || page <= 0 {
+		page = 1
+	}
+
+	// If page is provided but offset is not, calculate offset from page
+	if r.URL.Query().Get("page") != "" && r.URL.Query().Get("offset") == "" {
+		offset = (page - 1) * limit
+	}
+
+	return PaginationParams{
+		Offset: offset,
+		Limit:  limit,
+		Page:   page,
+	}
+}
+
+// SetPaginationHeaders sets the pagination headers on the response
+func SetPaginationHeaders(w http.ResponseWriter, params PaginationParams, totalCount int) {
+	w.Header().Set("X-Total-Count", strconv.Itoa(totalCount))
+
+	// Calculate total pages
+	totalPages := totalCount / params.Limit
+	if totalCount%params.Limit > 0 {
+		totalPages++
+	}
+	w.Header().Set("X-Total-Pages", strconv.Itoa(totalPages))
+
+	// Current page (calculated from offset and limit)
+	currentPage := (params.Offset / params.Limit) + 1
+	w.Header().Set("X-Current-Page", strconv.Itoa(currentPage))
+
+	// Page size
+	w.Header().Set("X-Page-Size", strconv.Itoa(params.Limit))
+}
+
+// CreatePaginationResponse creates a standard pagination response
+type PaginationResponse struct {
+	TotalCount  int         `json:"total_count"`
+	TotalPages  int         `json:"total_pages"`
+	CurrentPage int         `json:"current_page"`
+	PageSize    int         `json:"page_size"`
+	Data        interface{} `json:"data"`
+}
+
+// NewPaginationResponse creates a new pagination response
+func NewPaginationResponse(params PaginationParams, totalCount int, data interface{}) *PaginationResponse {
+	// Calculate total pages
+	totalPages := totalCount / params.Limit
+	if totalCount%params.Limit > 0 {
+		totalPages++
+	}
+
+	// Calculate current page from offset and limit
+	currentPage := (params.Offset / params.Limit) + 1
+
+	return &PaginationResponse{
+		TotalCount:  totalCount,
+		TotalPages:  totalPages,
+		CurrentPage: currentPage,
+		PageSize:    params.Limit,
+		Data:        data,
+	}
+}

--- a/internal/interfaces/api/server.go
+++ b/internal/interfaces/api/server.go
@@ -142,8 +142,8 @@ func (s *Server) setupRoutes() {
 
 	// Product routes (seller only)
 	protected.HandleFunc("/products", productHandler.CreateProduct).Methods(http.MethodPost)
-	protected.HandleFunc("/products/{id:[0-9]+}", productHandler.UpdateProduct).Methods(http.MethodPut)
-	protected.HandleFunc("/products/{id:[0-9]+}", productHandler.DeleteProduct).Methods(http.MethodDelete)
+	protected.HandleFunc("/products/{productId:[0-9]+}", productHandler.UpdateProduct).Methods(http.MethodPut)
+	protected.HandleFunc("/products/{productId:[0-9]+}", productHandler.DeleteProduct).Methods(http.MethodDelete)
 	protected.HandleFunc("/products/seller", productHandler.ListSellerProducts).Methods(http.MethodGet)
 
 	// Product variant routes (seller only)
@@ -160,9 +160,9 @@ func (s *Server) setupRoutes() {
 
 	// Order routes
 	protected.HandleFunc("/orders", orderHandler.CreateOrder).Methods(http.MethodPost)
-	protected.HandleFunc("/orders/{id:[0-9]+}", orderHandler.GetOrder).Methods(http.MethodGet)
+	protected.HandleFunc("/orders/{orderId:[0-9]+}", orderHandler.GetOrder).Methods(http.MethodGet)
 	protected.HandleFunc("/orders", orderHandler.ListOrders).Methods(http.MethodGet)
-	protected.HandleFunc("/orders/{id:[0-9]+}/payment", orderHandler.ProcessPayment).Methods(http.MethodPost)
+	protected.HandleFunc("/orders/{orderId:[0-9]+}/payment", orderHandler.ProcessPayment).Methods(http.MethodPost)
 
 	// Discount routes
 	protected.HandleFunc("/discounts", discountHandler.CreateDiscount).Methods(http.MethodPost)
@@ -179,7 +179,7 @@ func (s *Server) setupRoutes() {
 	admin.Use(middleware.AdminOnly)
 	admin.HandleFunc("/users", userHandler.ListUsers).Methods(http.MethodGet)
 	admin.HandleFunc("/orders", orderHandler.ListAllOrders).Methods(http.MethodGet)
-	admin.HandleFunc("/orders/{id:[0-9]+}/status", orderHandler.UpdateOrderStatus).Methods(http.MethodPut)
+	admin.HandleFunc("/orders/{orderId:[0-9]+}/status", orderHandler.UpdateOrderStatus).Methods(http.MethodPut)
 
 	// Admin currency routes
 	admin.HandleFunc("/currencies/all", currencyHandler.ListCurrencies).Methods(http.MethodGet)
@@ -190,14 +190,14 @@ func (s *Server) setupRoutes() {
 
 	// Shipping management routes (admin only)
 	admin.HandleFunc("/shipping/methods", shippingHandler.CreateShippingMethod).Methods(http.MethodPost)
-	admin.HandleFunc("/shipping/methods/{id:[0-9]+}", shippingHandler.UpdateShippingMethod).Methods(http.MethodPut)
+	admin.HandleFunc("/shipping/methods/{shippingMethodId:[0-9]+}", shippingHandler.UpdateShippingMethod).Methods(http.MethodPut)
 	admin.HandleFunc("/shipping/zones", shippingHandler.CreateShippingZone).Methods(http.MethodPost)
 	admin.HandleFunc("/shipping/zones", shippingHandler.ListShippingZones).Methods(http.MethodGet)
-	admin.HandleFunc("/shipping/zones/{id:[0-9]+}", shippingHandler.GetShippingZoneByID).Methods(http.MethodGet)
-	admin.HandleFunc("/shipping/zones/{id:[0-9]+}", shippingHandler.UpdateShippingZone).Methods(http.MethodPut)
+	admin.HandleFunc("/shipping/zones/{shippingZoneId:[0-9]+}", shippingHandler.GetShippingZoneByID).Methods(http.MethodGet)
+	admin.HandleFunc("/shipping/zones/{shippingZoneId:[0-9]+}", shippingHandler.UpdateShippingZone).Methods(http.MethodPut)
 	admin.HandleFunc("/shipping/rates", shippingHandler.CreateShippingRate).Methods(http.MethodPost)
-	admin.HandleFunc("/shipping/rates/{id:[0-9]+}", shippingHandler.GetShippingRateByID).Methods(http.MethodGet)
-	admin.HandleFunc("/shipping/rates/{id:[0-9]+}", shippingHandler.UpdateShippingRate).Methods(http.MethodPut)
+	admin.HandleFunc("/shipping/rates/{shippingRateId:[0-9]+}", shippingHandler.GetShippingRateByID).Methods(http.MethodGet)
+	admin.HandleFunc("/shipping/rates/{shippingRateId:[0-9]+}", shippingHandler.UpdateShippingRate).Methods(http.MethodPut)
 	admin.HandleFunc("/shipping/rates/weight", shippingHandler.CreateWeightBasedRate).Methods(http.MethodPost)
 	admin.HandleFunc("/shipping/rates/value", shippingHandler.CreateValueBasedRate).Methods(http.MethodPost)
 

--- a/internal/interfaces/api/server.go
+++ b/internal/interfaces/api/server.go
@@ -94,7 +94,10 @@ func (s *Server) setupRoutes() {
 	api.HandleFunc("/products/search", productHandler.SearchProducts).Methods(http.MethodGet)
 	api.HandleFunc("/categories", productHandler.ListCategories).Methods(http.MethodGet)
 	api.HandleFunc("/payment/providers", paymentHandler.GetAvailablePaymentProviders).Methods(http.MethodGet)
+
+	// Public discount routes
 	api.HandleFunc("/discounts/validate", discountHandler.ValidateDiscountCode).Methods(http.MethodPost)
+	api.HandleFunc("/guest/discounts/apply/{orderId:[0-9]+}", discountHandler.ApplyDiscountToGuestOrder).Methods(http.MethodPost)
 
 	// Public currency routes
 	api.HandleFunc("/currencies", currencyHandler.ListEnabledCurrencies).Methods(http.MethodGet)

--- a/internal/interfaces/api/server.go
+++ b/internal/interfaces/api/server.go
@@ -205,6 +205,7 @@ func (s *Server) setupRoutes() {
 	admin.HandleFunc("/payments/{paymentId}/capture", paymentHandler.CapturePayment).Methods(http.MethodPost)
 	admin.HandleFunc("/payments/{paymentId}/cancel", paymentHandler.CancelPayment).Methods(http.MethodPost)
 	admin.HandleFunc("/payments/{paymentId}/refund", paymentHandler.RefundPayment).Methods(http.MethodPost)
+	admin.HandleFunc("/payments/{paymentId}/force-approve", paymentHandler.ForceApproveMobilePayPayment).Methods(http.MethodPost)
 
 	// Webhook management routes (admin only)
 	admin.HandleFunc("/webhooks", webhookHandler.ListWebhooks).Methods(http.MethodGet)

--- a/postman_collection.json
+++ b/postman_collection.json
@@ -1,0 +1,983 @@
+{
+  "info": {
+    "name": "Commercify Order Flow Tests",
+    "description": "Collection for testing different order flow scenarios",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Setup - Get Products",
+      "item": [
+        {
+          "name": "List Products",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/products",
+              "host": ["{{base_url}}"],
+              "path": ["api", "products"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "1. Guest Order with Discount",
+      "item": [
+        {
+          "name": "Add iPhone to Guest Cart",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/guest/cart/items",
+              "host": ["{{base_url}}"],
+              "path": ["api", "guest", "cart", "items"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"product_id\": 1,\n  \"variant_id\": 1,\n  \"quantity\": 1\n}"
+            }
+          }
+        },
+        {
+          "name": "Add Samsung to Guest Cart",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/guest/cart/items",
+              "host": ["{{base_url}}"],
+              "path": ["api", "guest", "cart", "items"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"product_id\": 2,\n  \"variant_id\": 10,\n  \"quantity\": 1\n}"
+            }
+          }
+        },
+        {
+          "name": "Create Guest Order",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/guest/orders",
+              "host": ["{{base_url}}"],
+              "path": ["api", "guest", "orders"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"guest@example.com\",\n  \"full_name\": \"Guest User\",\n  \"phone_number\": \"+1234567890\",\n  \"shipping_address\": {\n    \"street_address\": \"123 Main St\",\n    \"city\": \"San Francisco\",\n    \"state\": \"CA\",\n    \"postal_code\": \"94105\",\n    \"country\": \"US\"\n  },\n  \"billing_address\": {\n    \"street_address\": \"123 Main St\",\n    \"city\": \"San Francisco\",\n    \"state\": \"CA\",\n    \"postal_code\": \"94105\",\n    \"country\": \"US\"\n  },\n  \"shipping_method_id\": 3\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "if (jsonData && jsonData.ID) {",
+                  "    pm.environment.set('order_id', jsonData.ID);",
+                  "    console.log('Order ID set to: ' + jsonData.ID);",
+                  "} else {",
+                  "    console.error('Failed to get order ID from response');",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Apply Discount",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/guest/discounts/apply/{{order_id}}",
+              "host": ["{{base_url}}"],
+              "path": ["api", "guest", "discounts", "apply", "{{order_id}}"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"discount_code\": \"WELCOME10\"\n}"
+            }
+          }
+        },
+        {
+          "name": "Process Payment",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/guest/orders/{{order_id}}/payment",
+              "host": ["{{base_url}}"],
+              "path": ["api", "guest", "orders", "{{order_id}}", "payment"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"payment_method\": \"credit_card\",\n  \"payment_provider\": \"stripe\",\n  \"card_details\": {\n    \"card_number\": \"4242 4242 4242 4242\",\n    \"expiry_month\": 12,\n    \"expiry_year\": 34,\n    \"cvv\": \"345\",\n    \"cardholder_name\": \"John Doe\",\n    \"token\": \"pm_card_visa\"\n  }\n}"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "2. Guest Order without Discount",
+      "item": [
+        {
+          "name": "Clear Guest Cart",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/guest/cart",
+              "host": ["{{base_url}}"],
+              "path": ["api", "guest", "cart"]
+            }
+          }
+        },
+        {
+          "name": "Add iPhone to Guest Cart",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/guest/cart/items",
+              "host": ["{{base_url}}"],
+              "path": ["api", "guest", "cart", "items"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"product_id\": 1,\n  \"variant_id\": 2,\n  \"quantity\": 1\n}"
+            }
+          }
+        },
+        {
+          "name": "Create Guest Order",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/guest/orders",
+              "host": ["{{base_url}}"],
+              "path": ["api", "guest", "orders"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"guest2@example.com\",\n  \"full_name\": \"Guest User 2\",\n  \"phone_number\": \"+1234567890\",\n  \"shipping_address\": {\n    \"street_address\": \"456 Oak St\",\n    \"city\": \"San Francisco\",\n    \"state\": \"CA\",\n    \"postal_code\": \"94105\",\n    \"country\": \"US\"\n  },\n  \"billing_address\": {\n    \"street_address\": \"456 Oak St\",\n    \"city\": \"San Francisco\",\n    \"state\": \"CA\",\n    \"postal_code\": \"94105\",\n    \"country\": \"US\"\n  },\n  \"shipping_method_id\": 3\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "if (jsonData && jsonData.ID) {",
+                  "    pm.environment.set('order_id', jsonData.ID);",
+                  "    console.log('Order ID set to: ' + jsonData.ID);",
+                  "} else {",
+                  "    console.error('Failed to get order ID from response');",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Process Payment",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/guest/orders/{{order_id}}/payment",
+              "host": ["{{base_url}}"],
+              "path": ["api", "guest", "orders", "{{order_id}}", "payment"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"payment_method\": \"credit_card\",\n  \"payment_provider\": \"stripe\",\n  \"card_details\": {\n    \"card_number\": \"4242 4242 4242 4242\",\n    \"expiry_month\": 12,\n    \"expiry_year\": 34,\n    \"cvv\": \"345\",\n    \"cardholder_name\": \"John Doe\",\n    \"token\": \"pm_card_visa\"\n  }\n}"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "3. User Order with Discount",
+      "item": [
+        {
+          "name": "Login",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/users/login",
+              "host": ["{{base_url}}"],
+              "path": ["api", "users", "login"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"{{user_email}}\",\n  \"password\": \"{{user_password}}\"\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "if (jsonData && jsonData.token) {",
+                  "    pm.environment.set('auth_token', jsonData.token);",
+                  "    console.log('Auth token set from login');",
+                  "} else {",
+                  "    console.error('Failed to get auth token from login response');",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Clear User Cart",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{auth_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/cart",
+              "host": ["{{base_url}}"],
+              "path": ["api", "cart"]
+            }
+          }
+        },
+        {
+          "name": "Add iPhone to User Cart",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{auth_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/cart/items",
+              "host": ["{{base_url}}"],
+              "path": ["api", "cart", "items"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"product_id\": 1,\n  \"variant_id\": 4,\n  \"quantity\": 1\n}"
+            }
+          }
+        },
+        {
+          "name": "Add Samsung to User Cart",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{auth_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/cart/items",
+              "host": ["{{base_url}}"],
+              "path": ["api", "cart", "items"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"product_id\": 2,\n  \"variant_id\": 13,\n  \"quantity\": 1\n}"
+            }
+          }
+        },
+        {
+          "name": "Create User Order",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{auth_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/orders",
+              "host": ["{{base_url}}"],
+              "path": ["api", "orders"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"shipping_method_id\": 3\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "if (jsonData && jsonData.ID) {",
+                  "    pm.environment.set('order_id', jsonData.ID);",
+                  "    console.log('Order ID set to: ' + jsonData.ID);",
+                  "} else {",
+                  "    console.error('Failed to get order ID from response');",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Apply Discount",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{auth_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/discounts/apply/{{order_id}}",
+              "host": ["{{base_url}}"],
+              "path": ["api", "discounts", "apply", "{{order_id}}"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"discount_code\": \"SAVE20\"\n}"
+            }
+          }
+        },
+        {
+          "name": "Process Payment",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{auth_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/orders/{{order_id}}/payment",
+              "host": ["{{base_url}}"],
+              "path": ["api", "orders", "{{order_id}}", "payment"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"payment_method\": \"credit_card\",\n  \"payment_provider\": \"stripe\",\n  \"card_details\": {\n    \"card_number\": \"4242 4242 4242 4242\",\n    \"expiry_month\": 12,\n    \"expiry_year\": 34,\n    \"cvv\": \"345\",\n    \"cardholder_name\": \"John Doe\",\n    \"token\": \"pm_card_visa\"\n  }\n}"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "4. User Order without Discount",
+      "item": [
+        {
+          "name": "Login",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/users/login",
+              "host": ["{{base_url}}"],
+              "path": ["api", "users", "login"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"{{user_email}}\",\n  \"password\": \"{{user_password}}\"\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "if (jsonData && jsonData.token) {",
+                  "    pm.environment.set('auth_token', jsonData.token);",
+                  "    console.log('Auth token set from login');",
+                  "} else {",
+                  "    console.error('Failed to get auth token from login response');",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Clear User Cart",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{auth_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/cart",
+              "host": ["{{base_url}}"],
+              "path": ["api", "cart"]
+            }
+          }
+        },
+        {
+          "name": "Add Samsung to User Cart",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{auth_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/cart/items",
+              "host": ["{{base_url}}"],
+              "path": ["api", "cart", "items"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"product_id\": 2,\n  \"variant_id\": 11,\n  \"quantity\": 1\n}"
+            }
+          }
+        },
+        {
+          "name": "Create User Order",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{auth_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/orders",
+              "host": ["{{base_url}}"],
+              "path": ["api", "orders"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"shipping_method_id\": 3\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "if (jsonData && jsonData.ID) {",
+                  "    pm.environment.set('order_id', jsonData.ID);",
+                  "    console.log('Order ID set to: ' + jsonData.ID);",
+                  "} else {",
+                  "    console.error('Failed to get order ID from response');",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Process Payment",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{auth_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/orders/{{order_id}}/payment",
+              "host": ["{{base_url}}"],
+              "path": ["api", "orders", "{{order_id}}", "payment"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"payment_method\": \"credit_card\",\n  \"payment_provider\": \"stripe\",\n  \"card_details\": {\n    \"card_number\": \"4242 4242 4242 4242\",\n    \"expiry_month\": 12,\n    \"expiry_year\": 34,\n    \"cvv\": \"345\",\n    \"cardholder_name\": \"John Doe\",\n    \"token\": \"pm_card_visa\"\n  }\n}"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "4. MobilePay Payment Tests",
+      "item": [
+        {
+          "name": "Guest Order with MobilePay",
+          "item": [
+            {
+              "name": "Add iPhone to Guest Cart",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": {
+                  "raw": "{{base_url}}/api/guest/cart/items",
+                  "host": ["{{base_url}}"],
+                  "path": ["api", "guest", "cart", "items"]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"product_id\": 1,\n  \"variant_id\": 1,\n  \"quantity\": 1\n}"
+                }
+              }
+            },
+            {
+              "name": "Create Guest Order",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": {
+                  "raw": "{{base_url}}/api/guest/orders",
+                  "host": ["{{base_url}}"],
+                  "path": ["api", "guest", "orders"]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"email\": \"mobilepay.guest@example.com\",\n  \"full_name\": \"MobilePay Guest\",\n  \"phone_number\": \"{{mobilepay_phone}}\",\n  \"shipping_address\": {\n    \"street_address\": \"123 MobilePay St\",\n    \"city\": \"Copenhagen\",\n    \"state\": \"\",\n    \"postal_code\": \"2100\",\n    \"country\": \"DK\"\n  },\n  \"billing_address\": {\n    \"street_address\": \"123 MobilePay St\",\n    \"city\": \"Copenhagen\",\n    \"state\": \"\",\n    \"postal_code\": \"2100\",\n    \"country\": \"DK\"\n  },\n  \"shipping_method_id\": 3\n}"
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "var jsonData = pm.response.json();",
+                      "if (jsonData && jsonData.ID) {",
+                      "    pm.environment.set('order_id', jsonData.ID);",
+                      "    console.log('Order ID set to: ' + jsonData.ID);",
+                      "} else {",
+                      "    console.error('Failed to get order ID from response');",
+                      "}"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Process MobilePay Payment",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": {
+                  "raw": "{{base_url}}/api/guest/orders/{{order_id}}/payment",
+                  "host": ["{{base_url}}"],
+                  "path": ["api", "guest", "orders", "{{order_id}}", "payment"]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"payment_method\": \"wallet\",\n  \"payment_provider\": \"mobilepay\",\n  \"phone_number\": \"{{mobilepay_phone}}\",\n  \"customer_email\": \"mobilepay.guest@example.com\"\n}"
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test('Payment response has correct structure', function() {",
+                      "    var jsonData = pm.response.json();",
+                      "    pm.expect(jsonData).to.have.property('ID');",
+                      "    pm.expect(jsonData).to.have.property('Status');",
+                      "    pm.expect(jsonData).to.have.property('PaymentProvider', 'mobilepay');",
+                      "    pm.expect(jsonData).to.have.property('ActionURL');",
+                      "    // Store the payment ID for force approve",
+                      "    if (jsonData.PaymentID) {",
+                      "        pm.environment.set('payment_id', jsonData.PaymentID);",
+                      "        console.log('Payment ID set to: ' + jsonData.PaymentID);",
+                      "    }",
+                      "});"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "User Order with MobilePay",
+          "item": [
+            {
+              "name": "Login",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": {
+                  "raw": "{{base_url}}/api/users/login",
+                  "host": ["{{base_url}}"],
+                  "path": ["api", "users", "login"]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"email\": \"{{user_email}}\",\n  \"password\": \"{{user_password}}\"\n}"
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "var jsonData = pm.response.json();",
+                      "if (jsonData && jsonData.token) {",
+                      "    pm.environment.set('auth_token', jsonData.token);",
+                      "    console.log('Auth token set successfully');",
+                      "} else {",
+                      "    console.error('Failed to get auth token');",
+                      "}"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Add iPhone to User Cart",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{auth_token}}"
+                  }
+                ],
+                "url": {
+                  "raw": "{{base_url}}/api/cart/items",
+                  "host": ["{{base_url}}"],
+                  "path": ["api", "cart", "items"]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"product_id\": 1,\n  \"variant_id\": 1,\n  \"quantity\": 1\n}"
+                }
+              }
+            },
+            {
+              "name": "Create User Order",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{auth_token}}"
+                  }
+                ],
+                "url": {
+                  "raw": "{{base_url}}/api/orders",
+                  "host": ["{{base_url}}"],
+                  "path": ["api", "orders"]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"shipping_address\": {\n    \"street_address\": \"123 MobilePay St\",\n    \"city\": \"Copenhagen\",\n    \"state\": \"\",\n    \"postal_code\": \"2100\",\n    \"country\": \"DK\"\n  },\n  \"billing_address\": {\n    \"street_address\": \"123 MobilePay St\",\n    \"city\": \"Copenhagen\",\n    \"state\": \"\",\n    \"postal_code\": \"2100\",\n    \"country\": \"DK\"\n  },\n  \"shipping_method_id\": 3\n}"
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "var jsonData = pm.response.json();",
+                      "if (jsonData && jsonData.ID) {",
+                      "    pm.environment.set('order_id', jsonData.ID);",
+                      "    console.log('Order ID set to: ' + jsonData.ID);",
+                      "} else {",
+                      "    console.error('Failed to get order ID from response');",
+                      "}"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Process MobilePay Payment",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{auth_token}}"
+                  }
+                ],
+                "url": {
+                  "raw": "{{base_url}}/api/orders/{{order_id}}/payment",
+                  "host": ["{{base_url}}"],
+                  "path": ["api", "orders", "{{order_id}}", "payment"]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"payment_method\": \"wallet\",\n  \"payment_provider\": \"mobilepay\",\n  \"phone_number\": \"{{mobilepay_phone}}\"\n}"
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test('Payment response has correct structure', function() {",
+                      "    var jsonData = pm.response.json();",
+                      "    pm.expect(jsonData).to.have.property('ID');",
+                      "    pm.expect(jsonData).to.have.property('Status');",
+                      "    pm.expect(jsonData).to.have.property('PaymentProvider', 'mobilepay');",
+                      "    pm.expect(jsonData).to.have.property('ActionURL');",
+                      "    // Store the payment ID for force approve",
+                      "    if (jsonData.PaymentID) {",
+                      "        pm.environment.set('payment_id', jsonData.PaymentID);",
+                      "        console.log('Payment ID set to: ' + jsonData.PaymentID);",
+                      "    }",
+                      "});"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Admin Authentication",
+          "item": [
+            {
+              "name": "Admin Login",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": {
+                  "raw": "{{base_url}}/api/users/login",
+                  "host": ["{{base_url}}"],
+                  "path": ["api", "users", "login"]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"email\": \"{{admin_email}}\",\n  \"password\": \"{{admin_password}}\"\n}"
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "var jsonData = pm.response.json();",
+                      "if (jsonData && jsonData.token) {",
+                      "    pm.environment.set('admin_token', jsonData.token);",
+                      "    console.log('Admin token set successfully');",
+                      "} else {",
+                      "    console.error('Failed to get admin token');",
+                      "}"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Admin - Force Approve MobilePay Payment",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{admin_token}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/admin/payments/{{payment_id}}/force-approve",
+              "host": ["{{base_url}}"],
+              "path": ["api", "admin", "payments", "{{payment_id}}", "force-approve"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"phone_number\": \"{{mobilepay_phone}}\"\n}"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "http://localhost:6091",
+      "type": "string"
+    },
+    {
+      "key": "auth_token",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "order_id",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "user_email",
+      "value": "user@example.com",
+      "type": "string"
+    },
+    {
+      "key": "user_password",
+      "value": "user123",
+      "type": "string"
+    },
+    {
+      "key": "admin_email",
+      "value": "admin@example.com",
+      "type": "string"
+    },
+    {
+      "key": "admin_password",
+      "value": "admin123",
+      "type": "string"
+    },
+    {
+      "key": "mobilepay_phone",
+      "value": "4512345678",
+      "type": "string"
+    }
+  ]
+} 

--- a/testutil/mock/cart_repository.go
+++ b/testutil/mock/cart_repository.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/zenfulcode/commercify/internal/domain/entity"
+	"github.com/zenfulcode/commercify/internal/domain/repository"
 )
 
 // MockCartRepository is a mock implementation of the CartRepository interface
@@ -18,7 +19,7 @@ type MockCartRepository struct {
 }
 
 // NewMockCartRepository creates a new mock cart repository
-func NewMockCartRepository() *MockCartRepository {
+func NewMockCartRepository() repository.CartRepository {
 	return &MockCartRepository{
 		carts:      make(map[uint]*entity.Cart),
 		guestCarts: make(map[string]*entity.Cart),

--- a/testutil/mock/category_repository.go
+++ b/testutil/mock/category_repository.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/zenfulcode/commercify/internal/domain/entity"
+	"github.com/zenfulcode/commercify/internal/domain/repository"
 )
 
 // MockCategoryRepository is a mock implementation of the category repository
@@ -13,7 +14,7 @@ type MockCategoryRepository struct {
 }
 
 // NewMockCategoryRepository creates a new instance of MockCategoryRepository
-func NewMockCategoryRepository() *MockCategoryRepository {
+func NewMockCategoryRepository() repository.CategoryRepository {
 	return &MockCategoryRepository{
 		categories: make(map[uint]*entity.Category),
 		lastID:     0,

--- a/testutil/mock/currency_repository.go
+++ b/testutil/mock/currency_repository.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/zenfulcode/commercify/internal/domain/entity"
 	"github.com/zenfulcode/commercify/internal/domain/money"
+	"github.com/zenfulcode/commercify/internal/domain/repository"
 )
 
 type MockCurrencyRepository struct {
@@ -12,7 +13,7 @@ type MockCurrencyRepository struct {
 	defaultCurrency *entity.Currency
 }
 
-func NewMockCurrencyRepository() *MockCurrencyRepository {
+func NewMockCurrencyRepository() repository.CurrencyRepository {
 	return &MockCurrencyRepository{
 		currencies: make(map[string]*entity.Currency),
 		defaultCurrency: &entity.Currency{

--- a/testutil/mock/discount_repository.go
+++ b/testutil/mock/discount_repository.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/zenfulcode/commercify/internal/domain/entity"
+	"github.com/zenfulcode/commercify/internal/domain/repository"
 )
 
 // MockDiscountRepository is a mock implementation of the discount repository
@@ -14,7 +15,7 @@ type MockDiscountRepository struct {
 }
 
 // NewMockDiscountRepository creates a new instance of MockDiscountRepository
-func NewMockDiscountRepository() *MockDiscountRepository {
+func NewMockDiscountRepository() repository.DiscountRepository {
 	return &MockDiscountRepository{
 		discounts:      make(map[uint]*entity.Discount),
 		discountByCode: make(map[string]*entity.Discount),

--- a/testutil/mock/order_repository.go
+++ b/testutil/mock/order_repository.go
@@ -4,20 +4,24 @@ import (
 	"errors"
 
 	"github.com/zenfulcode/commercify/internal/domain/entity"
+	"github.com/zenfulcode/commercify/internal/domain/repository"
 )
 
 // OrderRepository is a mock implementation of the order repository interface
 type OrderRepository struct {
-	orders               map[uint]*entity.Order
-	paymentIDIndex       map[string]*entity.Order // Index to find orders by payment ID
-	MockIsDiscountIdUsed func(id uint) (bool, error)
+	orders           map[uint]*entity.Order
+	paymentIDIndex   map[string]*entity.Order // Index to find orders by payment ID
+	isDiscountIdUsed bool
 }
 
 // NewMockOrderRepository creates a new mock order repository
-func NewMockOrderRepository() *OrderRepository {
+func NewMockOrderRepository(
+	isDiscountIdUsed bool,
+) repository.OrderRepository {
 	return &OrderRepository{
-		orders:         make(map[uint]*entity.Order),
-		paymentIDIndex: make(map[string]*entity.Order),
+		orders:           make(map[uint]*entity.Order),
+		paymentIDIndex:   make(map[string]*entity.Order),
+		isDiscountIdUsed: isDiscountIdUsed,
 	}
 }
 
@@ -120,11 +124,14 @@ func (r *OrderRepository) ListByStatus(status entity.OrderStatus, offset, limit 
 	return orders[offset:end], nil
 }
 
+func (r *OrderRepository) SetIsDiscountIdUsed(isDiscountIdUsed bool) {
+	r.isDiscountIdUsed = isDiscountIdUsed
+}
+
 // IsDiscountIdUsed checks if a discount is used by any order in the mock repository
 func (r *OrderRepository) IsDiscountIdUsed(discountID uint) (bool, error) {
-	// If a mock function is provided, use it
-	if r.MockIsDiscountIdUsed != nil {
-		return r.MockIsDiscountIdUsed(discountID)
+	if r.isDiscountIdUsed {
+		return true, nil
 	}
 
 	// Otherwise fall back to the default implementation

--- a/testutil/mock/payment_transaction_repository.go
+++ b/testutil/mock/payment_transaction_repository.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/zenfulcode/commercify/internal/domain/entity"
+	"github.com/zenfulcode/commercify/internal/domain/repository"
 )
 
 // MockPaymentTransactionRepository implements a mock payment transaction repository for testing
@@ -16,7 +17,7 @@ type MockPaymentTransactionRepository struct {
 }
 
 // NewMockPaymentTransactionRepository creates a new mock payment transaction repository
-func NewMockPaymentTransactionRepository() *MockPaymentTransactionRepository {
+func NewMockPaymentTransactionRepository() repository.PaymentTransactionRepository {
 	return &MockPaymentTransactionRepository{
 		transactions:    make(map[uint]*entity.PaymentTransaction),
 		byOrderID:       make(map[uint][]*entity.PaymentTransaction),

--- a/testutil/mock/product_repository.go
+++ b/testutil/mock/product_repository.go
@@ -10,24 +10,34 @@ import (
 
 // MockProductRepository is a mock implementation of product repository for testing
 type MockProductRepository struct {
-	products map[uint]*entity.Product
-	bySeller map[uint][]*entity.Product
-	lastID   uint
-	// Add MockSearch function field for custom search behavior in tests
-	MockSearch func(query string, categoryID uint, minPrice, maxPrice int64, offset, limit int) ([]*entity.Product, error)
+	products    map[uint]*entity.Product
+	bySeller    map[uint][]*entity.Product
+	lastID      uint
+	searchCount int
 }
 
 // NewMockProductRepository creates a new instance of MockProductRepository
 func NewMockProductRepository() repository.ProductRepository {
 	return &MockProductRepository{
-		products: make(map[uint]*entity.Product),
-		bySeller: make(map[uint][]*entity.Product),
-		lastID:   0,
+		products:    make(map[uint]*entity.Product),
+		bySeller:    make(map[uint][]*entity.Product),
+		lastID:      0,
+		searchCount: 0,
 	}
 }
 
 // Count returns the number of products in the repository
 func (r *MockProductRepository) Count() (int, error) {
+	return len(r.products), nil
+}
+
+// CountBySeller implements repository.ProductRepository.
+func (r *MockProductRepository) CountBySeller(sellerID uint) (int, error) {
+	return len(r.bySeller[sellerID]), nil
+}
+
+// CountSearch implements repository.ProductRepository.
+func (r *MockProductRepository) CountSearch(searchQuery string, categoryID uint, minPriceCents int64, maxPriceCents int64) (int, error) {
 	return len(r.products), nil
 }
 
@@ -112,10 +122,6 @@ func (r *MockProductRepository) List(offset, limit int) ([]*entity.Product, erro
 
 // Search searches for products based on criteria
 func (r *MockProductRepository) Search(query string, categoryID uint, minPrice, maxPrice int64, offset, limit int) ([]*entity.Product, error) {
-	if r.MockSearch != nil {
-		// Use the custom search function if provided
-		return r.MockSearch(query, categoryID, minPrice, maxPrice, offset, limit)
-	}
 
 	result := make([]*entity.Product, 0)
 	count := 0

--- a/testutil/mock/product_repository.go
+++ b/testutil/mock/product_repository.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/zenfulcode/commercify/internal/domain/entity"
+	"github.com/zenfulcode/commercify/internal/domain/repository"
 )
 
 // MockProductRepository is a mock implementation of product repository for testing
@@ -17,12 +18,17 @@ type MockProductRepository struct {
 }
 
 // NewMockProductRepository creates a new instance of MockProductRepository
-func NewMockProductRepository() *MockProductRepository {
+func NewMockProductRepository() repository.ProductRepository {
 	return &MockProductRepository{
 		products: make(map[uint]*entity.Product),
 		bySeller: make(map[uint][]*entity.Product),
 		lastID:   0,
 	}
+}
+
+// Count returns the number of products in the repository
+func (r *MockProductRepository) Count() (int, error) {
+	return len(r.products), nil
 }
 
 // Create adds a product to the repository

--- a/testutil/mock/product_variant_repository.go
+++ b/testutil/mock/product_variant_repository.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/zenfulcode/commercify/internal/domain/entity"
+	"github.com/zenfulcode/commercify/internal/domain/repository"
 )
 
 // MockProductVariantRepository is a mock implementation of product variant repository for testing
@@ -15,7 +16,7 @@ type MockProductVariantRepository struct {
 }
 
 // NewMockProductVariantRepository creates a new instance of MockProductVariantRepository
-func NewMockProductVariantRepository() *MockProductVariantRepository {
+func NewMockProductVariantRepository() repository.ProductVariantRepository {
 	return &MockProductVariantRepository{
 		variants:          make(map[uint]*entity.ProductVariant),
 		variantsBySKU:     make(map[string]*entity.ProductVariant),

--- a/testutil/mock/user_repository.go
+++ b/testutil/mock/user_repository.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/zenfulcode/commercify/internal/domain/entity"
+	"github.com/zenfulcode/commercify/internal/domain/repository"
 )
 
 // MockUserRepository is a mock implementation of user repository for testing
@@ -14,7 +15,7 @@ type MockUserRepository struct {
 }
 
 // NewMockUserRepository creates a new instance of MockUserRepository
-func NewMockUserRepository() *MockUserRepository {
+func NewMockUserRepository() repository.UserRepository {
 	return &MockUserRepository{
 		users:       make(map[uint]*entity.User),
 		userByEmail: make(map[string]*entity.User),


### PR DESCRIPTION
This pull request introduces several changes across different areas of the codebase, including modifications to the seeding logic, adjustments to the `Cart` repository methods in tests, and updates to the `Discount` use case tests. The most significant updates involve refactoring the structure of product variant attributes, replacing a repository method in test cases, and enhancing the mock order repository initialization.

### Changes to seeding logic:

* Commented out the seeding logic for orders and payment transactions in `cmd/seed/main.go`, likely as part of a temporary or debugging measure.
* Refactored the `attributes` field in `seedProductVariants` from a `map[string]string` to a `[]map[string]string` to better support structured attribute data. This change affects multiple locations in the `cmd/seed/main.go` file. [[1]](diffhunk://#diff-6ddee65c1af4eca0731181077e1a58367799008dc6d252fbcda9715a5dd70404L547-R547) [[2]](diffhunk://#diff-6ddee65c1af4eca0731181077e1a58367799008dc6d252fbcda9715a5dd70404L568-R568) [[3]](diffhunk://#diff-6ddee65c1af4eca0731181077e1a58367799008dc6d252fbcda9715a5dd70404L577-R580) [[4]](diffhunk://#diff-6ddee65c1af4eca0731181077e1a58367799008dc6d252fbcda9715a5dd70404L602-R605) [[5]](diffhunk://#diff-6ddee65c1af4eca0731181077e1a58367799008dc6d252fbcda9715a5dd70404L611-R617) [[6]](diffhunk://#diff-6ddee65c1af4eca0731181077e1a58367799008dc6d252fbcda9715a5dd70404L641-R642) [[7]](diffhunk://#diff-6ddee65c1af4eca0731181077e1a58367799008dc6d252fbcda9715a5dd70404L650-R653)

### Changes to `Cart` repository methods in tests:

* Replaced calls to `cartRepo.CreateWithID` with `cartRepo.Create` in various test cases in `internal/application/usecase/cart_usecase_test.go`, simplifying the repository interface and aligning it with the standard `Create` method. [[1]](diffhunk://#diff-9bf3308198dd988e70d673dd870a32899b3c2e0a57e89c5ac6387359c5edeea5L24-R24) [[2]](diffhunk://#diff-9bf3308198dd988e70d673dd870a32899b3c2e0a57e89c5ac6387359c5edeea5L71-R71) [[3]](diffhunk://#diff-9bf3308198dd988e70d673dd870a32899b3c2e0a57e89c5ac6387359c5edeea5L124-R124) [[4]](diffhunk://#diff-9bf3308198dd988e70d673dd870a32899b3c2e0a57e89c5ac6387359c5edeea5L183-R183) [[5]](diffhunk://#diff-9bf3308198dd988e70d673dd870a32899b3c2e0a57e89c5ac6387359c5edeea5L231-R231) [[6]](diffhunk://#diff-9bf3308198dd988e70d673dd870a32899b3c2e0a57e89c5ac6387359c5edeea5L270-R270) [[7]](diffhunk://#diff-9bf3308198dd988e70d673dd870a32899b3c2e0a57e89c5ac6387359c5edeea5L317-R317) [[8]](diffhunk://#diff-9bf3308198dd988e70d673dd870a32899b3c2e0a57e89c5ac6387359c5edeea5L380-R380) [[9]](diffhunk://#diff-9bf3308198dd988e70d673dd870a32899b3c2e0a57e89c5ac6387359c5edeea5L465-R465) [[10]](diffhunk://#diff-9bf3308198dd988e70d673dd870a32899b3c2e0a57e89c5ac6387359c5edeea5L524-R524) [[11]](diffhunk://#diff-9bf3308198dd988e70d673dd870a32899b3c2e0a57e89c5ac6387359c5edeea5L572-R572) [[12]](diffhunk://#diff-9bf3308198dd988e70d673dd870a32899b3c2e0a57e89c5ac6387359c5edeea5L620-R620) [[13]](diffhunk://#diff-9bf3308198dd988e70d673dd870a32899b3c2e0a57e89c5ac6387359c5edeea5L671-R671) [[14]](diffhunk://#diff-9bf3308198dd988e70d673dd870a32899b3c2e0a57e89c5ac6387359c5edeea5L730-R730) [[15]](diffhunk://#diff-9bf3308198dd988e70d673dd870a32899b3c2e0a57e89c5ac6387359c5edeea5L786-R786) [[16]](diffhunk://#diff-9bf3308198dd988e70d673dd870a32899b3c2e0a57e89c5ac6387359c5edeea5L852-R852) [[17]](diffhunk://#diff-9bf3308198dd988e70d673dd870a32899b3c2e0a57e89c5ac6387359c5edeea5L899-R899) [[18]](diffhunk://#diff-9bf3308198dd988e70d673dd870a32899b3c2e0a57e89c5ac6387359c5edeea5L929-R929)

### Updates to `Discount` use case tests:

* Updated the initialization of `mock.NewMockOrderRepository` in `internal/application/usecase/discount_usecase_test.go` to include a `false` parameter, likely to control specific behavior in the mock implementation. [[1]](diffhunk://#diff-f9866615e74aa9dfa54995d02624cd09614020774ef0f72db926acc2854d5d74L20-R20) [[2]](diffhunk://#diff-f9866615e74aa9dfa54995d02624cd09614020774ef0f72db926acc2854d5d74L69-R69) [[3]](diffhunk://#diff-f9866615e74aa9dfa54995d02624cd09614020774ef0f72db926acc2854d5d74L119-R119) [[4]](diffhunk://#diff-f9866615e74aa9dfa54995d02624cd09614020774ef0f72db926acc2854d5d74L171-R171) [[5]](diffhunk://#diff-f9866615e74aa9dfa54995d02624cd09614020774ef0f72db926acc2854d5d74L225-R225) [[6]](diffhunk://#diff-f9866615e74aa9dfa54995d02624cd09614020774ef0f72db926acc2854d5d74L265-R265) [[7]](diffhunk://#diff-f9866615e74aa9dfa54995d02624cd09614020774ef0f72db926acc2854d5d74L304-R304) [[8]](diffhunk://#diff-f9866615e74aa9dfa54995d02624cd09614020774ef0f72db926acc2854d5d74L345-R345)