### PR TITLE
feat: Update Docker image name to use repository variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: zenfulcode/commercifygo
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-push:
@@ -14,8 +14,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      attestations: write
-      id-token: write
 
     steps:
       - name: Checkout repository
@@ -28,22 +26,18 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
 
-      - name: Debug repository info
+      - name: Convert repository name to lowercase
         run: |
-          echo "Repository: ${{ github.repository }}"
-          echo "Repository owner: ${{ github.repository_owner }}"
-          echo "Image name: ${{ env.IMAGE_NAME }}"
-          echo "Registry: ${{ env.REGISTRY }}"
-          echo "Full image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          echo "IMAGE_NAME_LOWER=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LOWER }}
           tags: |
             type=ref,event=tag
             type=semver,pattern={{version}}


### PR DESCRIPTION
This pull request updates the `.github/workflows/release.yml` file to improve flexibility and security in the Docker image publishing workflow. The changes primarily involve using dynamic values for the image name, updating credentials, and ensuring the repository name is properly formatted.

### Workflow improvements:

* Updated `IMAGE_NAME` to dynamically use the GitHub repository name instead of a hardcoded value, enhancing flexibility for different repositories. (`[.github/workflows/release.ymlL9-L18](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L9-L18)`)
* Changed Docker login credentials to use `GHCR_TOKEN` if available, falling back to `GITHUB_TOKEN` for improved security and compatibility. (`[.github/workflows/release.ymlL31-R40](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L31-R40)`)
* Added a step to convert the repository name to lowercase and save it as an environment variable (`IMAGE_NAME_LOWER`) for consistent Docker image naming. (`[.github/workflows/release.ymlL31-R40](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L31-R40)`)

### Metadata adjustments:

* Updated the `images` parameter in the Docker metadata action to use the new `IMAGE_NAME_LOWER` environment variable, ensuring proper formatting for image tags and labels. (`[.github/workflows/release.ymlL31-R40](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L31-R40)`)